### PR TITLE
[codex] Remove number input spinners

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -67,6 +67,17 @@
   option {
     @apply bg-background text-foreground;
   }
+
+  input[type='number'] {
+    appearance: textfield;
+    -moz-appearance: textfield;
+  }
+
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 }
 
 .sales-dispatch-gatepass-print-blocked {


### PR DESCRIPTION
﻿## What changed

- Hide browser spinner controls on numeric inputs using shared base CSS.
- Covers Chromium/WebKit browsers and Firefox while keeping inputs numeric.

## Why

Barcode forms show default increment/decrement arrows on number fields, which makes the input UI noisy and inconsistent with the rest of the form controls.

## Validation

- Ran `npm run build` successfully.
