### PR TITLE
Add Admin module for docking scan-skip approvals + weight comparison

### DIFF
--- a/src/app/layouts/components/MobileSidebar.tsx
+++ b/src/app/layouts/components/MobileSidebar.tsx
@@ -110,6 +110,7 @@ function MobileSidebar({ isOpen, onClose }: MobileSidebarProps) {
           {navItems.map((item) => {
             // Icon comes directly from module config, fallback to LayoutDashboard
             const Icon = item.icon || LayoutDashboard;
+            const Badge = item.badge;
             const hasSubmenu = item.hasSubmenu && item.children && item.children.length > 0;
             const isOpen = hasSubmenu ? isSubmenuOpen(item.path) : false;
             const isActive = isRouteActive(item);
@@ -135,6 +136,7 @@ function MobileSidebar({ isOpen, onClose }: MobileSidebarProps) {
                     >
                       <Icon className="h-5 w-5" />
                       <span>{item.title}</span>
+                      {Badge ? <Badge className="ml-auto" /> : null}
                     </NavLink>
                     <Button
                       variant="ghost"
@@ -156,6 +158,7 @@ function MobileSidebar({ isOpen, onClose }: MobileSidebarProps) {
                   <CollapsibleContent className="ml-4 space-y-1 border-l pl-3">
                     {item.children!.map((child) => {
                       const childIsActive = location.pathname === child.path;
+                      const ChildBadge = child.badge;
                       return (
                         <NavLink
                           key={child.path}
@@ -171,6 +174,7 @@ function MobileSidebar({ isOpen, onClose }: MobileSidebarProps) {
                           }
                         >
                           <span>{child.title}</span>
+                          {ChildBadge ? <ChildBadge className="ml-auto" /> : null}
                         </NavLink>
                       );
                     })}

--- a/src/app/layouts/components/Sidebar.tsx
+++ b/src/app/layouts/components/Sidebar.tsx
@@ -144,6 +144,7 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
         {navItems.map((item) => {
           // Icon comes directly from module config, fallback to LayoutDashboard
           const Icon = item.icon || LayoutDashboard;
+          const Badge = item.badge;
           const hasSubmenu = item.hasSubmenu && item.children && item.children.length > 0;
           const isOpen = hasSubmenu ? isSubmenuOpen(item.path) : false;
           const isActive = isRouteActive(item);
@@ -156,7 +157,7 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
                     to={item.path}
                     className={({ isActive }) =>
                       cn(
-                        'flex h-10 w-10 items-center justify-center rounded-md transition-colors',
+                        'relative flex h-10 w-10 items-center justify-center rounded-md transition-colors',
                         isActive
                           ? 'bg-primary text-primary-foreground'
                           : 'hover:bg-accent hover:text-accent-foreground',
@@ -164,6 +165,9 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
                     }
                   >
                     <Icon className="h-5 w-5" />
+                    {Badge ? (
+                      <Badge className="absolute -right-1 -top-1 h-4 min-w-[1rem] px-1 text-[10px]" />
+                    ) : null}
                   </NavLink>
                 </TooltipTrigger>
                 <TooltipContent side="right">{item.title}</TooltipContent>
@@ -192,6 +196,7 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
                   >
                     <Icon className="h-5 w-5" />
                     <span>{item.title}</span>
+                    {Badge ? <Badge className="ml-auto" /> : null}
                   </NavLink>
                   <Button
                     variant="ghost"
@@ -213,6 +218,7 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
                 <CollapsibleContent className="ml-4 space-y-1 border-l pl-3">
                   {item.children!.map((child) => {
                     const childIsActive = location.pathname === child.path;
+                    const ChildBadge = child.badge;
                     return (
                       <NavLink
                         key={child.path}
@@ -227,6 +233,7 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
                         }
                       >
                         <span>{child.title}</span>
+                        {ChildBadge ? <ChildBadge className="ml-auto" /> : null}
                       </NavLink>
                     );
                   })}
@@ -251,6 +258,7 @@ export function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
             >
               <Icon className="h-5 w-5" />
               <span>{item.title}</span>
+              {Badge ? <Badge className="ml-auto" /> : null}
             </NavLink>
           );
         })}

--- a/src/app/registry/index.ts
+++ b/src/app/registry/index.ts
@@ -3,7 +3,9 @@ import type { Reducer } from '@reduxjs/toolkit';
 import type { ModuleConfig, ModuleNavItem, ModuleRoute } from '@/core/types';
 // Module configuration imports
 // Each module exports its own routes, navigation, and reducers
+import { adminModuleConfig } from '@/modules/admin/module.config';
 import { authModuleConfig } from '@/modules/auth/module.config';
+import { barcodeModuleConfig } from '@/modules/barcode/module.config';
 import { dashboardModuleConfig } from '@/modules/dashboard/module.config';
 import { dashboardsModuleConfig } from '@/modules/dashboards/module.config';
 import { dispatchModuleConfig } from '@/modules/dispatch/module.config';
@@ -16,7 +18,6 @@ import { qcModuleConfig } from '@/modules/qc/module.config';
 import { settingsModuleConfig } from '@/modules/settings/module.config';
 import { vehicleManagementModuleConfig } from '@/modules/vehicle-management/module.config';
 import { warehouseModuleConfig } from '@/modules/warehouse/module.config';
-import { barcodeModuleConfig } from '@/modules/barcode/module.config';
 
 /**
  * Central registry of all feature modules
@@ -24,6 +25,7 @@ import { barcodeModuleConfig } from '@/modules/barcode/module.config';
  */
 export const moduleRegistry: ModuleConfig[] = [
   authModuleConfig,
+  adminModuleConfig,
   dashboardModuleConfig,
   dashboardsModuleConfig,
   dispatchModuleConfig,

--- a/src/config/constants/api.constants.ts
+++ b/src/config/constants/api.constants.ts
@@ -177,6 +177,16 @@ export const API_ENDPOINTS = {
       UNREGISTER: '/notifications/devices/unregister/',
     },
   },
+  // Admin - Docking (scan skip approvals)
+  DOCKING_ADMIN: {
+    SCAN_SKIP_REQUESTS: '/docking-admin/scan-skip-requests/',
+    SCAN_SKIP_REQUEST_BY_DISPATCH: (entryId: number) =>
+      `/docking-admin/scan-skip-requests/by-sales-dispatch/${entryId}/`,
+    SCAN_SKIP_REQUEST_APPROVE: (id: number) =>
+      `/docking-admin/scan-skip-requests/${id}/approve/`,
+    SCAN_SKIP_REQUEST_REJECT: (id: number) =>
+      `/docking-admin/scan-skip-requests/${id}/reject/`,
+  },
   // Quality Control V2 (New QC Module)
   QUALITY_CONTROL_V2: {
     // Arrival Slips

--- a/src/config/permissions/admin.permissions.ts
+++ b/src/config/permissions/admin.permissions.ts
@@ -1,0 +1,24 @@
+/**
+ * Admin Module Permissions
+ *
+ * These constants map to Django permissions defined in the backend `docking_admin` app.
+ * Format: 'app_label.permission_codename'
+ */
+
+export const ADMIN_PERMISSIONS = {
+  DOCKING: {
+    /** Operator can request to skip box scanning for a docking entry */
+    REQUEST_SCAN_SKIP: 'docking_admin.can_request_docking_scan_skip',
+    /** View docking scan skip requests (admin queue) */
+    VIEW_SCAN_SKIP: 'docking_admin.can_view_docking_scan_skip',
+    /** Approve or reject docking scan skip requests */
+    APPROVE_SCAN_SKIP: 'docking_admin.can_approve_docking_scan_skip',
+  },
+} as const;
+
+/** Module prefix for sidebar filtering */
+export const ADMIN_MODULE_PREFIX = 'docking_admin';
+
+/** Type for admin permission values (Django backend permissions). */
+export type AdminPermission =
+  (typeof ADMIN_PERMISSIONS.DOCKING)[keyof typeof ADMIN_PERMISSIONS.DOCKING];

--- a/src/config/permissions/index.ts
+++ b/src/config/permissions/index.ts
@@ -9,6 +9,9 @@
  * import { QC_PERMISSIONS } from '@/config/permissions'
  */
 
+// Admin Module
+export { ADMIN_MODULE_PREFIX, ADMIN_PERMISSIONS, type AdminPermission } from './admin.permissions';
+
 // Gate Module
 export { GATE_MODULE_PREFIX, GATE_PERMISSIONS, type GatePermission } from './gate.permissions';
 

--- a/src/core/types/module.types.ts
+++ b/src/core/types/module.types.ts
@@ -1,5 +1,6 @@
 import type { Reducer } from '@reduxjs/toolkit';
 import type { LucideIcon } from 'lucide-react';
+import type { ComponentType } from 'react';
 
 /**
  * Navigation item configuration for sidebar menu
@@ -21,6 +22,12 @@ export interface ModuleNavItem {
   hasSubmenu?: boolean;
   /** Child navigation items for submenus */
   children?: ModuleNavItem[];
+  /**
+   * Optional badge component rendered next to the title (and overlaid on the icon when
+   * collapsed). Used for live indicators such as a pending-approval count. The component
+   * fetches its own data and should render nothing when there is nothing to show.
+   */
+  badge?: ComponentType<{ className?: string }>;
 }
 
 /**

--- a/src/modules/admin/api/dockingApproval.api.ts
+++ b/src/modules/admin/api/dockingApproval.api.ts
@@ -1,0 +1,95 @@
+import { API_ENDPOINTS } from '@/config/constants';
+import { apiClient } from '@/core/api';
+
+export type DockingScanSkipStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+
+export interface DockingScanSkipRequest {
+  id: number;
+  sales_dispatch: number;
+  entry_no: string;
+  vehicle_no: string;
+  customer_name: string;
+  sap_doc_num: string;
+  document_type: string;
+  dispatch_status: string;
+  reason: string;
+  status: DockingScanSkipStatus;
+  requested_by: number | null;
+  requested_by_name: string;
+  requested_at: string;
+  reviewed_by: number | null;
+  reviewed_by_name: string;
+  reviewed_at: string | null;
+  review_notes: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export type DockingScanSkipListParams = {
+  status?: DockingScanSkipStatus;
+  sales_dispatch?: number;
+};
+
+export interface DockingScanSkipCreateRequest {
+  sales_dispatch: number;
+  reason: string;
+}
+
+export interface DockingScanSkipReviewRequest {
+  notes?: string;
+}
+
+function buildQuery(params?: Record<string, string | number | undefined>) {
+  const queryParams = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value !== undefined && value !== '') {
+      queryParams.append(key, String(value));
+    }
+  });
+  return queryParams.toString();
+}
+
+export const dockingApprovalApi = {
+  async list(params?: DockingScanSkipListParams): Promise<DockingScanSkipRequest[]> {
+    const query = buildQuery(params);
+    const url = query
+      ? `${API_ENDPOINTS.DOCKING_ADMIN.SCAN_SKIP_REQUESTS}?${query}`
+      : API_ENDPOINTS.DOCKING_ADMIN.SCAN_SKIP_REQUESTS;
+    const response = await apiClient.get<DockingScanSkipRequest[]>(url);
+    return response.data;
+  },
+
+  async byDispatch(entryId: number): Promise<DockingScanSkipRequest | null> {
+    const response = await apiClient.get<DockingScanSkipRequest | null>(
+      API_ENDPOINTS.DOCKING_ADMIN.SCAN_SKIP_REQUEST_BY_DISPATCH(entryId),
+    );
+    return response.data ?? null;
+  },
+
+  async create(data: DockingScanSkipCreateRequest): Promise<DockingScanSkipRequest> {
+    const response = await apiClient.post<DockingScanSkipRequest>(
+      API_ENDPOINTS.DOCKING_ADMIN.SCAN_SKIP_REQUESTS,
+      data,
+    );
+    return response.data;
+  },
+
+  async approve(
+    id: number,
+    data: DockingScanSkipReviewRequest = {},
+  ): Promise<DockingScanSkipRequest> {
+    const response = await apiClient.post<DockingScanSkipRequest>(
+      API_ENDPOINTS.DOCKING_ADMIN.SCAN_SKIP_REQUEST_APPROVE(id),
+      data,
+    );
+    return response.data;
+  },
+
+  async reject(id: number, data: DockingScanSkipReviewRequest): Promise<DockingScanSkipRequest> {
+    const response = await apiClient.post<DockingScanSkipRequest>(
+      API_ENDPOINTS.DOCKING_ADMIN.SCAN_SKIP_REQUEST_REJECT(id),
+      data,
+    );
+    return response.data;
+  },
+};

--- a/src/modules/admin/api/dockingApproval.queries.ts
+++ b/src/modules/admin/api/dockingApproval.queries.ts
@@ -1,0 +1,71 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  dockingApprovalApi,
+  type DockingScanSkipCreateRequest,
+  type DockingScanSkipListParams,
+  type DockingScanSkipReviewRequest,
+} from './dockingApproval.api';
+
+export const DOCKING_APPROVAL_QUERY_KEYS = {
+  all: ['dockingScanSkip'] as const,
+  list: (params?: DockingScanSkipListParams) =>
+    [...DOCKING_APPROVAL_QUERY_KEYS.all, 'list', params] as const,
+  byDispatch: (entryId?: number | null) =>
+    [...DOCKING_APPROVAL_QUERY_KEYS.all, 'byDispatch', entryId] as const,
+};
+
+function invalidateDockingApproval(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: DOCKING_APPROVAL_QUERY_KEYS.all });
+  // The scan page gates "Continue" on the docking entry's skip status.
+  queryClient.invalidateQueries({ queryKey: ['salesDispatch'] });
+}
+
+export function useDockingScanSkipRequests(
+  params?: DockingScanSkipListParams,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: DOCKING_APPROVAL_QUERY_KEYS.list(params),
+    queryFn: () => dockingApprovalApi.list(params),
+    staleTime: 15 * 1000,
+    enabled: options?.enabled ?? true,
+  });
+}
+
+export function useDockingScanSkipRequestByDispatch(entryId?: number | null) {
+  return useQuery({
+    queryKey: DOCKING_APPROVAL_QUERY_KEYS.byDispatch(entryId),
+    queryFn: () => dockingApprovalApi.byDispatch(entryId as number),
+    enabled: Boolean(entryId),
+  });
+}
+
+export function useCreateDockingScanSkipRequest() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: DockingScanSkipCreateRequest) => dockingApprovalApi.create(data),
+    onSuccess: () => invalidateDockingApproval(queryClient),
+  });
+}
+
+export function useApproveDockingScanSkipRequest() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data?: DockingScanSkipReviewRequest }) =>
+      dockingApprovalApi.approve(id, data),
+    onSuccess: () => invalidateDockingApproval(queryClient),
+  });
+}
+
+export function useRejectDockingScanSkipRequest() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: DockingScanSkipReviewRequest }) =>
+      dockingApprovalApi.reject(id, data),
+    onSuccess: () => invalidateDockingApproval(queryClient),
+  });
+}

--- a/src/modules/admin/api/index.ts
+++ b/src/modules/admin/api/index.ts
@@ -1,0 +1,6 @@
+// ============================================================================
+// Admin Module API Barrel Export
+// ============================================================================
+
+export * from './dockingApproval.api';
+export * from './dockingApproval.queries';

--- a/src/modules/admin/components/DockingApprovalsBadge.tsx
+++ b/src/modules/admin/components/DockingApprovalsBadge.tsx
@@ -1,0 +1,36 @@
+import { ADMIN_PERMISSIONS } from '@/config/permissions';
+import { usePermission } from '@/core/auth';
+import { useDockingScanSkipRequests } from '@/modules/admin/api';
+import { cn } from '@/shared/utils';
+
+/**
+ * Live count of pending docking scan-skip requests, rendered as a small pill in the
+ * sidebar. Renders nothing when there are no pending requests or the user cannot view them.
+ */
+export function DockingApprovalsBadge({ className }: { className?: string }) {
+  const { hasAnyPermission } = usePermission();
+  const canView = hasAnyPermission([
+    ADMIN_PERMISSIONS.DOCKING.VIEW_SCAN_SKIP,
+    ADMIN_PERMISSIONS.DOCKING.APPROVE_SCAN_SKIP,
+  ]);
+
+  const { data } = useDockingScanSkipRequests(
+    { status: 'PENDING' },
+    { enabled: canView },
+  );
+
+  const count = data?.length ?? 0;
+  if (count <= 0) return null;
+
+  return (
+    <span
+      className={cn(
+        'inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1.5 text-[11px] font-semibold leading-none text-white',
+        className,
+      )}
+      aria-label={`${count} pending docking approval${count === 1 ? '' : 's'}`}
+    >
+      {count > 99 ? '99+' : count}
+    </span>
+  );
+}

--- a/src/modules/admin/module.config.tsx
+++ b/src/modules/admin/module.config.tsx
@@ -1,0 +1,54 @@
+import { ShieldCheck } from 'lucide-react';
+import { lazy } from 'react';
+
+import { ADMIN_PERMISSIONS } from '@/config/permissions';
+import type { ModuleConfig } from '@/core/types';
+
+import { DockingApprovalsBadge } from './components/DockingApprovalsBadge';
+
+const AdminDashboardPage = lazy(() => import('./pages/AdminDashboardPage'));
+const DockingScanApprovalsPage = lazy(() => import('./pages/DockingScanApprovalsPage'));
+
+const dockingApprovalPermissions = [
+  ADMIN_PERMISSIONS.DOCKING.VIEW_SCAN_SKIP,
+  ADMIN_PERMISSIONS.DOCKING.APPROVE_SCAN_SKIP,
+] as const;
+
+export const adminModuleConfig: ModuleConfig = {
+  name: 'admin',
+  routes: [
+    {
+      path: '/admin',
+      element: <AdminDashboardPage />,
+      layout: 'main',
+      permissions: dockingApprovalPermissions,
+      breadcrumb: { label: 'Admin' },
+    },
+    {
+      path: '/admin/docking/scan-approvals',
+      element: <DockingScanApprovalsPage />,
+      layout: 'main',
+      permissions: dockingApprovalPermissions,
+      breadcrumb: { label: 'Scan Skip Requests' },
+    },
+  ],
+  navigation: [
+    {
+      path: '/admin',
+      title: 'Admin',
+      icon: ShieldCheck,
+      showInSidebar: true,
+      permissions: dockingApprovalPermissions,
+      hasSubmenu: true,
+      badge: DockingApprovalsBadge,
+      children: [
+        {
+          path: '/admin/docking/scan-approvals',
+          title: 'Docking Approvals',
+          permissions: dockingApprovalPermissions,
+          badge: DockingApprovalsBadge,
+        },
+      ],
+    },
+  ],
+};

--- a/src/modules/admin/pages/AdminDashboardPage.tsx
+++ b/src/modules/admin/pages/AdminDashboardPage.tsx
@@ -1,0 +1,78 @@
+import { ClipboardCheck, Truck } from 'lucide-react';
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { ADMIN_PERMISSIONS } from '@/config/permissions';
+import { usePermission } from '@/core/auth';
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/components/ui';
+
+interface AdminModuleCard {
+  title: string;
+  description: string;
+  route: string;
+  icon: React.ReactNode;
+  color: string;
+  permissions: readonly string[];
+}
+
+const adminModuleCards: AdminModuleCard[] = [
+  {
+    title: 'Docking — Scan Skip Requests',
+    description: 'Review and approve operator requests to skip box scanning for docking entries.',
+    route: '/admin/docking/scan-approvals',
+    icon: <ClipboardCheck className="h-5 w-5" />,
+    color: 'text-emerald-700',
+    permissions: [
+      ADMIN_PERMISSIONS.DOCKING.VIEW_SCAN_SKIP,
+      ADMIN_PERMISSIONS.DOCKING.APPROVE_SCAN_SKIP,
+    ],
+  },
+];
+
+export default function AdminDashboardPage() {
+  const navigate = useNavigate();
+  const { hasAnyPermission } = usePermission();
+
+  const visibleCards = useMemo(
+    () => adminModuleCards.filter((card) => hasAnyPermission([...card.permissions])),
+    [hasAnyPermission],
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="flex items-center gap-2 text-3xl font-bold tracking-tight">
+          <Truck className="h-7 w-7" />
+          Admin
+        </h2>
+        <p className="text-muted-foreground">Administrative review and approval queues.</p>
+      </div>
+
+      {visibleCards.length === 0 ? (
+        <Card>
+          <CardContent className="p-8 text-center text-muted-foreground">
+            You do not have access to any admin queues.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {visibleCards.map((card) => (
+            <Card
+              key={card.route}
+              className="cursor-pointer transition-all hover:border-primary/50 hover:shadow-md"
+              onClick={() => navigate(card.route)}
+            >
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">{card.title}</CardTitle>
+                <div className={card.color}>{card.icon}</div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm leading-5 text-muted-foreground">{card.description}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/admin/pages/DockingScanApprovalsPage.tsx
+++ b/src/modules/admin/pages/DockingScanApprovalsPage.tsx
@@ -1,0 +1,301 @@
+import { CheckCircle2, ClipboardCheck, Loader2, ShieldQuestion, XCircle } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { ADMIN_PERMISSIONS } from '@/config/permissions';
+import { usePermission } from '@/core/auth';
+import {
+  type DockingScanSkipRequest,
+  type DockingScanSkipStatus,
+  useApproveDockingScanSkipRequest,
+  useDockingScanSkipRequests,
+  useRejectDockingScanSkipRequest,
+} from '@/modules/admin/api';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Label,
+  Textarea,
+} from '@/shared/components/ui';
+import { cn, getErrorMessage } from '@/shared/utils';
+
+type StatusFilter = DockingScanSkipStatus | 'ALL';
+
+const STATUS_TABS: { value: StatusFilter; label: string }[] = [
+  { value: 'PENDING', label: 'Pending' },
+  { value: 'APPROVED', label: 'Approved' },
+  { value: 'REJECTED', label: 'Rejected' },
+  { value: 'ALL', label: 'All' },
+];
+
+export default function DockingScanApprovalsPage() {
+  const { hasPermission } = usePermission();
+  const canApprove = hasPermission(ADMIN_PERMISSIONS.DOCKING.APPROVE_SCAN_SKIP);
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('PENDING');
+  const { data: requests = [], isLoading } = useDockingScanSkipRequests(
+    statusFilter === 'ALL' ? undefined : { status: statusFilter },
+  );
+
+  const approveRequest = useApproveDockingScanSkipRequest();
+  const rejectRequest = useRejectDockingScanSkipRequest();
+
+  const [reviewTarget, setReviewTarget] = useState<DockingScanSkipRequest | null>(null);
+  const [reviewMode, setReviewMode] = useState<'approve' | 'reject'>('approve');
+  const [notes, setNotes] = useState('');
+  const [reviewError, setReviewError] = useState('');
+
+  const isSaving = approveRequest.isPending || rejectRequest.isPending;
+
+  const openReview = (request: DockingScanSkipRequest, mode: 'approve' | 'reject') => {
+    setReviewTarget(request);
+    setReviewMode(mode);
+    setNotes('');
+    setReviewError('');
+  };
+
+  const closeReview = () => {
+    if (isSaving) return;
+    setReviewTarget(null);
+  };
+
+  const submitReview = async () => {
+    if (!reviewTarget) return;
+    const trimmed = notes.trim();
+    if (reviewMode === 'reject' && !trimmed) {
+      setReviewError('A note is required when rejecting a request.');
+      return;
+    }
+    setReviewError('');
+    try {
+      if (reviewMode === 'approve') {
+        await approveRequest.mutateAsync({ id: reviewTarget.id, data: { notes: trimmed } });
+        toast.success('Scan skip request approved');
+      } else {
+        await rejectRequest.mutateAsync({ id: reviewTarget.id, data: { notes: trimmed } });
+        toast.success('Scan skip request rejected');
+      }
+      setReviewTarget(null);
+    } catch (error) {
+      setReviewError(getErrorMessage(error, 'Unable to save this review'));
+    }
+  };
+
+  return (
+    <div className="space-y-6 pb-6">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight">Docking — Scan Skip Requests</h2>
+        <p className="text-muted-foreground">
+          Review operator requests to skip box scanning for docking entries. Approving unlocks the
+          scanning step for the operator.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="border-b">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <CardTitle className="flex items-center gap-2 text-xl">
+              <ClipboardCheck className="h-5 w-5" />
+              Requests
+            </CardTitle>
+            <div className="flex flex-wrap gap-2">
+              {STATUS_TABS.map((tab) => (
+                <Button
+                  key={tab.value}
+                  type="button"
+                  size="sm"
+                  variant={statusFilter === tab.value ? 'default' : 'outline'}
+                  onClick={() => setStatusFilter(tab.value)}
+                >
+                  {tab.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 p-10 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading requests...
+            </div>
+          ) : requests.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 p-10 text-center text-muted-foreground">
+              <ShieldQuestion className="h-8 w-8" />
+              <p>No {statusFilter === 'ALL' ? '' : statusFilter.toLowerCase()} scan skip requests.</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[920px] text-sm">
+                <thead className="border-b bg-muted/50">
+                  <tr>
+                    <th className="p-3 text-left font-medium">Docking Entry</th>
+                    <th className="p-3 text-left font-medium">Vehicle</th>
+                    <th className="p-3 text-left font-medium">Customer / Doc</th>
+                    <th className="p-3 text-left font-medium">Reason</th>
+                    <th className="p-3 text-left font-medium">Requested By</th>
+                    <th className="p-3 text-left font-medium">Status</th>
+                    <th className="p-3 text-right font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {requests.map((request) => (
+                    <tr key={request.id} className="border-b align-top last:border-b-0">
+                      <td className="p-3">
+                        <div className="font-medium">{request.entry_no || `#${request.sales_dispatch}`}</div>
+                        <div className="text-xs text-muted-foreground">{request.document_type}</div>
+                      </td>
+                      <td className="p-3">{request.vehicle_no || '-'}</td>
+                      <td className="p-3">
+                        <div className="font-medium">{request.customer_name || '-'}</div>
+                        <div className="text-xs text-muted-foreground">{request.sap_doc_num || '-'}</div>
+                      </td>
+                      <td className="p-3">
+                        <div className="max-w-[260px] whitespace-pre-wrap break-words">
+                          {request.reason}
+                        </div>
+                        {request.review_notes ? (
+                          <div className="mt-1 max-w-[260px] whitespace-pre-wrap break-words text-xs text-muted-foreground">
+                            Note: {request.review_notes}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className="p-3">
+                        <div className="font-medium">{request.requested_by_name || '-'}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatTimestamp(request.requested_at)}
+                        </div>
+                      </td>
+                      <td className="p-3">
+                        <StatusBadge status={request.status} />
+                        {request.reviewed_by_name ? (
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            by {request.reviewed_by_name}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className="p-3 text-right">
+                        {request.status === 'PENDING' && canApprove ? (
+                          <div className="flex justify-end gap-2">
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              disabled={isSaving}
+                              onClick={() => openReview(request, 'approve')}
+                            >
+                              <CheckCircle2 className="h-4 w-4" />
+                              Approve
+                            </Button>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              className="border-red-200 text-red-700 hover:bg-red-50"
+                              disabled={isSaving}
+                              onClick={() => openReview(request, 'reject')}
+                            >
+                              <XCircle className="h-4 w-4" />
+                              Reject
+                            </Button>
+                          </div>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            {request.status === 'PENDING' ? 'Awaiting approver' : 'Reviewed'}
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={Boolean(reviewTarget)} onOpenChange={(open) => (!open ? closeReview() : null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {reviewMode === 'approve' ? 'Approve Scan Skip' : 'Reject Scan Skip'}
+            </DialogTitle>
+            <DialogDescription>
+              {reviewMode === 'approve'
+                ? 'The operator will be able to continue past box scanning for this docking entry.'
+                : 'The operator will be required to scan boxes normally. Explain why this request is rejected.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="scan-skip-review-notes">
+              {reviewMode === 'approve' ? 'Note (optional)' : 'Reason for rejection'}
+            </Label>
+            <Textarea
+              id="scan-skip-review-notes"
+              value={notes}
+              onChange={(event) => {
+                setNotes(event.target.value);
+                setReviewError('');
+              }}
+              placeholder={
+                reviewMode === 'approve'
+                  ? 'Add an optional note for the audit trail'
+                  : 'Why is this request rejected?'
+              }
+            />
+            {reviewError ? <p className="text-sm text-destructive">{reviewError}</p> : null}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={closeReview} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant={reviewMode === 'reject' ? 'destructive' : 'default'}
+              onClick={() => void submitReview()}
+              disabled={isSaving}
+            >
+              {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {reviewMode === 'approve' ? 'Approve' : 'Reject'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: DockingScanSkipStatus }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        status === 'PENDING' && 'border-amber-200 bg-amber-50 text-amber-700',
+        status === 'APPROVED' && 'border-emerald-200 bg-emerald-50 text-emerald-700',
+        status === 'REJECTED' && 'border-red-200 bg-red-50 text-red-700',
+      )}
+    >
+      {status}
+    </Badge>
+  );
+}
+
+function formatTimestamp(value?: string | null) {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '-';
+  return new Intl.DateTimeFormat('en-IN', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}

--- a/src/modules/gate/api/salesDispatch/salesDispatch.api.ts
+++ b/src/modules/gate/api/salesDispatch/salesDispatch.api.ts
@@ -61,6 +61,8 @@ export interface SalesDispatchGatepassReadiness {
   missing: string[];
   has_truck_photo_geolocation: boolean;
   has_box_scans: boolean;
+  /** True when an admin-approved scan-skip request satisfies the box-scan requirement. */
+  scan_skip_approved?: boolean;
   has_weighment: boolean;
   has_items: boolean;
   has_bilty_details?: boolean;
@@ -152,6 +154,8 @@ export interface SalesDispatchBoxScan {
   batch_number?: string;
   quantity?: string | null;
   uom?: string;
+  net_weight?: string | null;
+  gross_weight?: string | null;
   box_status?: string;
   warehouse_code?: string;
   pallet_code?: string;

--- a/src/modules/gate/pages/customerSalesFlow/SalesDispatchBarcodeScanPage.tsx
+++ b/src/modules/gate/pages/customerSalesFlow/SalesDispatchBarcodeScanPage.tsx
@@ -1,11 +1,14 @@
 import {
   AlertCircle,
+  Ban,
   Camera,
   CheckCircle2,
   ClipboardList,
+  Clock3,
   Loader2,
   PackageCheck,
   ScanLine,
+  ShieldCheck,
   Trash2,
   Truck,
 } from 'lucide-react';
@@ -13,8 +16,13 @@ import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
-import { GATE_PERMISSIONS } from '@/config/permissions';
+import { ADMIN_PERMISSIONS, GATE_PERMISSIONS } from '@/config/permissions';
 import { usePermission } from '@/core/auth';
+import {
+  type DockingScanSkipRequest,
+  useCreateDockingScanSkipRequest,
+  useDockingScanSkipRequestByDispatch,
+} from '@/modules/admin/api';
 import { useScanner } from '@/modules/barcode/hooks/useScanner';
 import {
   type SalesDispatchBoxScan,
@@ -35,17 +43,24 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Input,
   Label,
+  Textarea,
 } from '@/shared/components/ui';
 import { cn, getErrorMessage } from '@/shared/utils';
 
-import { DOCKING_TOTAL_STEPS, formatTimestamp, formatValue } from './salesDispatchFlow.helpers';
 import {
   getExpectedDispatchBoxes,
   getExpectedItemBoxes,
   parsePositiveNumber,
 } from './salesDispatchBoxCounts';
+import { DOCKING_TOTAL_STEPS, formatTimestamp, formatValue } from './salesDispatchFlow.helpers';
 import { DOCKING_ROUTES } from './salesDispatchRoutes';
 
 type ScanSource = 'camera' | 'manual';
@@ -60,10 +75,13 @@ const SCAN_CLOSED_STATUSES = [
 
 export default function SalesDispatchBarcodeScanPage() {
   const navigate = useNavigate();
-  const { hasAnyPermission } = usePermission();
+  const { hasAnyPermission, hasPermission } = usePermission();
   const { entryId, entryIdNumber } = useEntryId();
   const [manualBarcode, setManualBarcode] = useState('');
   const [error, setError] = useState('');
+  const [isSkipDialogOpen, setIsSkipDialogOpen] = useState(false);
+  const [skipReason, setSkipReason] = useState('');
+  const [skipError, setSkipError] = useState('');
   const manualInputRef = useRef<HTMLInputElement>(null);
 
   const {
@@ -73,8 +91,10 @@ export default function SalesDispatchBarcodeScanPage() {
     refetch: refetchEntry,
   } = useSalesDispatchByVehicleEntry(entryIdNumber);
   const { data: scans = [], isLoading: isScansLoading } = useSalesDispatchBoxScans(entry?.id);
+  const { data: skipRequest } = useDockingScanSkipRequestByDispatch(entry?.id);
   const scanBox = useScanSalesDispatchBox();
   const removeScan = useRemoveSalesDispatchBoxScan();
+  const createSkipRequest = useCreateDockingScanSkipRequest();
 
   const isReadOnly = entry ? SCAN_CLOSED_STATUSES.includes(entry.status) : false;
   const closedScanRedirectPath = getClosedScanRedirectPath(entry);
@@ -82,6 +102,10 @@ export default function SalesDispatchBarcodeScanPage() {
     GATE_PERMISSIONS.SALES_DISPATCH.CREATE,
     GATE_PERMISSIONS.SALES_DISPATCH.EDIT,
   ]);
+  const canRequestScanSkip = hasPermission(ADMIN_PERMISSIONS.DOCKING.REQUEST_SCAN_SKIP);
+  const skipStatus = skipRequest?.status ?? null;
+  const isSkipApproved = skipStatus === 'APPROVED';
+  const isSkipPending = skipStatus === 'PENDING';
   const isSaving = scanBox.isPending || removeScan.isPending;
 
   const expectedBoxes = getExpectedDispatchBoxes(entry);
@@ -179,11 +203,35 @@ export default function SalesDispatchBarcodeScanPage() {
       setError('Docking details not found.');
       return;
     }
-    if (scans.length === 0) {
-      setError('Scan at least one box before moving to attachments.');
+    if (scans.length === 0 && !isSkipApproved) {
+      if (isSkipPending) {
+        setError(
+          'Box scanning skip is awaiting admin approval. You can continue once it is approved.',
+        );
+      } else {
+        setError('Scan at least one box, or request approval to skip scanning.');
+      }
       return;
     }
     navigate(DOCKING_ROUTES.attachments(entry.vehicle_entry));
+  };
+
+  const handleSubmitSkipRequest = async () => {
+    if (!entry) return;
+    const trimmedReason = skipReason.trim();
+    if (!trimmedReason) {
+      setSkipError('Enter a reason for skipping box scanning.');
+      return;
+    }
+    setSkipError('');
+    try {
+      await createSkipRequest.mutateAsync({ sales_dispatch: entry.id, reason: trimmedReason });
+      setIsSkipDialogOpen(false);
+      setSkipReason('');
+      toast.success('Scan skip request sent for admin approval');
+    } catch (submitError) {
+      setSkipError(getErrorMessage(submitError, 'Unable to submit the skip request'));
+    }
   };
 
   if (isEntryLoading || isScansLoading) {
@@ -231,6 +279,18 @@ export default function SalesDispatchBarcodeScanPage() {
         items={itemScanSummary.items}
         unplannedScanCount={itemScanSummary.unplannedScanCount}
         itemSummary={entry.item_summary}
+      />
+
+      <ScanSkipPanel
+        skipRequest={skipRequest}
+        canRequest={canRequestScanSkip && !isReadOnly && canEditDocking}
+        hasScans={scans.length > 0}
+        isSubmitting={createSkipRequest.isPending}
+        onRequest={() => {
+          setSkipReason('');
+          setSkipError('');
+          setIsSkipDialogOpen(true);
+        }}
       />
 
       <section className="grid gap-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
@@ -442,6 +502,55 @@ export default function SalesDispatchBarcodeScanPage() {
         isSaving={isSaving}
         nextLabel="Continue to Attachments"
       />
+
+      <Dialog
+        open={isSkipDialogOpen}
+        onOpenChange={(open) => {
+          if (createSkipRequest.isPending) return;
+          setIsSkipDialogOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Request to Skip Box Scanning</DialogTitle>
+            <DialogDescription>
+              Send this Docking entry to Admin for approval to continue without scanning boxes. You
+              cannot continue until an admin approves the request.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="docking-scan-skip-reason">Reason</Label>
+            <Textarea
+              id="docking-scan-skip-reason"
+              value={skipReason}
+              onChange={(event) => {
+                setSkipReason(event.target.value);
+                setSkipError('');
+              }}
+              placeholder="Why should box scanning be skipped for this Docking entry?"
+            />
+            {skipError ? <p className="text-sm text-destructive">{skipError}</p> : null}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setIsSkipDialogOpen(false)}
+              disabled={createSkipRequest.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void handleSubmitSkipRequest()}
+              disabled={createSkipRequest.isPending || !skipReason.trim()}
+            >
+              {createSkipRequest.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              Send for Approval
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -592,6 +701,99 @@ function ScanMetric({ label, value }: { label: string; value: string }) {
     <div className="rounded-md border bg-muted/20 p-3">
       <p className="text-xs text-muted-foreground">{label}</p>
       <p className="mt-1 text-xl font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function ScanSkipPanel({
+  skipRequest,
+  canRequest,
+  hasScans,
+  isSubmitting,
+  onRequest,
+}: {
+  skipRequest?: DockingScanSkipRequest | null;
+  canRequest: boolean;
+  hasScans: boolean;
+  isSubmitting: boolean;
+  onRequest: () => void;
+}) {
+  const status = skipRequest?.status ?? null;
+
+  if (status === 'APPROVED') {
+    return (
+      <div className="flex items-start gap-3 rounded-md border border-emerald-200 bg-emerald-50 p-4 text-emerald-900">
+        <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0" />
+        <div className="space-y-1">
+          <p className="font-medium">Scanning skip approved</p>
+          <p className="text-sm">
+            {skipRequest?.reviewed_by_name
+              ? `Approved by ${skipRequest.reviewed_by_name}. `
+              : ''}
+            You can continue to attachments without scanning boxes.
+          </p>
+          {skipRequest?.review_notes ? (
+            <p className="text-sm text-emerald-800">Note: {skipRequest.review_notes}</p>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'PENDING') {
+    return (
+      <div className="flex items-start gap-3 rounded-md border border-amber-300 bg-amber-50 p-4 text-amber-900">
+        <Clock3 className="mt-0.5 h-5 w-5 shrink-0" />
+        <div className="space-y-1">
+          <p className="font-medium">Scanning skip pending approval</p>
+          <p className="text-sm">
+            An admin must approve this request before you can continue without scanning. You can
+            still scan boxes to proceed normally.
+          </p>
+          {skipRequest?.reason ? (
+            <p className="text-sm text-amber-800">Reason: {skipRequest.reason}</p>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  // Rejected or no request yet.
+  const wasRejected = status === 'REJECTED';
+
+  if (!wasRejected && !canRequest) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-start gap-3">
+        <Ban className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+        <div className="space-y-1">
+          <p className="font-medium">
+            {wasRejected ? 'Scanning skip rejected' : "Can't scan these boxes?"}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {wasRejected
+              ? 'Please scan boxes to continue, or raise a new skip request.'
+              : 'Request admin approval to continue without scanning boxes for this Docking entry.'}
+          </p>
+          {wasRejected && skipRequest?.review_notes ? (
+            <p className="text-sm text-red-700">Reason: {skipRequest.review_notes}</p>
+          ) : null}
+        </div>
+      </div>
+      {canRequest ? (
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onRequest}
+          disabled={isSubmitting || hasScans}
+          title={hasScans ? 'Remove scans before requesting a skip' : undefined}
+        >
+          {wasRejected ? 'Request Again' : 'Request to Skip Scanning'}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/src/modules/gate/pages/customerSalesFlow/SalesDispatchGateOutWeighmentPage.tsx
+++ b/src/modules/gate/pages/customerSalesFlow/SalesDispatchGateOutWeighmentPage.tsx
@@ -1,14 +1,17 @@
-import { AlertCircle, FileText, Scale, Truck } from 'lucide-react';
+import { AlertCircle, Boxes, ClipboardList, FileText, PackageCheck, Scale, Truck } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import {
   type CreateWeighmentRequest,
-  type Weighment,
+  type SalesDispatchBoxScan,
+  type SalesDispatchGateOut,
+  type SalesDispatchItem,
   useCreateWeighment,
   useSalesDispatchByVehicleEntry,
   useWeighment,
+  type Weighment,
 } from '@/modules/gate/api';
 import {
   RequiredWeighmentForm,
@@ -23,8 +26,9 @@ import {
   type RequiredWeighmentValues,
 } from '@/modules/gate/utils';
 import { Button, Card, CardContent, CardHeader, CardTitle } from '@/shared/components/ui';
-import { getErrorMessage } from '@/shared/utils';
+import { cn, getErrorMessage } from '@/shared/utils';
 
+import { getExpectedDispatchBoxes, parsePositiveNumber } from './salesDispatchBoxCounts';
 import { formatTimestamp, formatValue, toTimeInputValue } from './salesDispatchFlow.helpers';
 import { getSalesDispatchRoutes } from './salesDispatchRoutes';
 
@@ -171,6 +175,23 @@ export default function SalesDispatchGateOutWeighmentPage() {
     ? getErrorMessage(weighmentError, 'Unable to load existing weighment')
     : '';
 
+  const scans = entry.box_scans ?? [];
+  const scannedBoxes = scans.length;
+  const scannedQty = scans.reduce((sum, scan) => sum + parsePositiveNumber(scan.quantity), 0);
+  const scannedNetWeight = scans.reduce(
+    (sum, scan) => sum + parsePositiveNumber(scan.net_weight),
+    0,
+  );
+  const expectedBoxes = getExpectedDispatchBoxes(entry);
+  const invoiceItems = getInvoiceItems(entry);
+  const invoiceWeight = parsePositiveNumber(entry.total_weight);
+  const invoiceBoxes = parsePositiveNumber(entry.total_boxes);
+  const scanSkipApproved = Boolean(entry.gatepass_readiness?.scan_skip_approved);
+
+  const grossNum = toFiniteNumber(values.grossWeight);
+  const tareNum = toFiniteNumber(values.tareWeight);
+  const netWeight = grossNum !== null && tareNum !== null ? grossNum - tareNum : null;
+
   return (
     <div className="space-y-6 pb-6">
       <StepHeader
@@ -225,6 +246,25 @@ export default function SalesDispatchGateOutWeighmentPage() {
         requiredFields={{ grossWeight: true, tareWeight: true }}
       />
 
+      <WeightCheckCard
+        invoiceWeight={invoiceWeight}
+        gross={grossNum}
+        tare={tareNum}
+        net={netWeight}
+      />
+
+      <DockingLoadCard
+        scans={scans}
+        scannedBoxes={scannedBoxes}
+        scannedQty={scannedQty}
+        scannedNetWeight={scannedNetWeight}
+        expectedBoxes={expectedBoxes}
+        invoiceItems={invoiceItems}
+        invoiceWeight={invoiceWeight}
+        invoiceBoxes={invoiceBoxes}
+        scanSkipApproved={scanSkipApproved}
+      />
+
       <StepFooter
         onPrevious={() => navigate(routes.detail(entry.id))}
         onCancel={() => navigate(routes.dashboard)}
@@ -246,6 +286,275 @@ function InfoItem({ label, value }: { label: string; value?: string | number | n
       <div className="mt-1 font-medium">{formatValue(value)}</div>
     </div>
   );
+}
+
+const VARIANCE_TONE = {
+  good: { box: 'border-emerald-200 bg-emerald-50 text-emerald-800', label: 'Within tolerance' },
+  warn: { box: 'border-amber-200 bg-amber-50 text-amber-800', label: 'Check the load' },
+  bad: { box: 'border-red-200 bg-red-50 text-red-800', label: 'Large weight mismatch' },
+  neutral: { box: 'border-slate-200 bg-slate-50 text-slate-700', label: 'Comparison' },
+} as const;
+
+function getVarianceTone(pct: number | null): keyof typeof VARIANCE_TONE {
+  if (pct === null) return 'neutral';
+  const abs = Math.abs(pct);
+  if (abs <= 2) return 'good';
+  if (abs <= 5) return 'warn';
+  return 'bad';
+}
+
+function WeightCheckCard({
+  invoiceWeight,
+  gross,
+  tare,
+  net,
+}: {
+  invoiceWeight: number;
+  gross: number | null;
+  tare: number | null;
+  net: number | null;
+}) {
+  const hasInvoiceWeight = invoiceWeight > 0;
+  const variance = net !== null && hasInvoiceWeight ? net - invoiceWeight : null;
+  const variancePct =
+    variance !== null && hasInvoiceWeight ? (variance / invoiceWeight) * 100 : null;
+  const tone = getVarianceTone(variancePct);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Scale className="h-5 w-5" />
+          Invoice vs Loaded Weight
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <MetricTile
+            label="Invoice Weight"
+            value={hasInvoiceWeight ? formatKg(invoiceWeight) : 'Not on invoice'}
+            hint="Expected product weight"
+          />
+          <MetricTile
+            label="Gross Weight"
+            value={gross !== null ? formatKg(gross) : '—'}
+            hint="Loaded vehicle"
+          />
+          <MetricTile
+            label="Tare Weight"
+            value={tare !== null ? formatKg(tare) : '—'}
+            hint="Empty vehicle"
+          />
+          <MetricTile
+            label="Net Weight"
+            value={net !== null ? formatKg(net) : '—'}
+            hint="Gross − Tare"
+            emphasis
+          />
+        </div>
+
+        {net === null ? (
+          <p className="text-sm text-muted-foreground">
+            Enter gross and tare weight to compare the loaded net weight against the invoice.
+          </p>
+        ) : !hasInvoiceWeight ? (
+          <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+            This invoice has no weight to compare against. Net loaded weight is {formatKg(net)}.
+          </div>
+        ) : (
+          <div
+            className={cn(
+              'flex flex-wrap items-center justify-between gap-2 rounded-md border p-3 text-sm',
+              VARIANCE_TONE[tone].box,
+            )}
+          >
+            <span className="font-medium">{VARIANCE_TONE[tone].label}</span>
+            <span>
+              Net {formatKg(net)} vs Invoice {formatKg(invoiceWeight)} ·{' '}
+              <span className="font-semibold">
+                {variance !== null && variance >= 0 ? '+' : ''}
+                {variance !== null ? formatKg(variance) : '—'}
+                {variancePct !== null
+                  ? ` (${variancePct >= 0 ? '+' : ''}${variancePct.toFixed(1)}%)`
+                  : ''}
+              </span>
+            </span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DockingLoadCard({
+  scans,
+  scannedBoxes,
+  scannedQty,
+  scannedNetWeight,
+  expectedBoxes,
+  invoiceItems,
+  invoiceWeight,
+  invoiceBoxes,
+  scanSkipApproved,
+}: {
+  scans: SalesDispatchBoxScan[];
+  scannedBoxes: number;
+  scannedQty: number;
+  scannedNetWeight: number;
+  expectedBoxes: number;
+  invoiceItems: SalesDispatchItem[];
+  invoiceWeight: number;
+  invoiceBoxes: number;
+  scanSkipApproved: boolean;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Boxes className="h-5 w-5" />
+          Docking Load
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          <MetricTile
+            label="Scanned Boxes"
+            value={
+              expectedBoxes > 0
+                ? `${scannedBoxes} / ${formatNumber(expectedBoxes)}`
+                : String(scannedBoxes)
+            }
+            hint="Boxes scanned at docking"
+          />
+          <MetricTile label="Scanned Qty" value={scannedQty > 0 ? formatNumber(scannedQty) : '—'} />
+          <MetricTile
+            label="Scanned Net Weight"
+            value={scannedNetWeight > 0 ? formatKg(scannedNetWeight) : '—'}
+            hint="Sum of scanned box weights"
+          />
+          <MetricTile label="Invoice Boxes" value={invoiceBoxes > 0 ? formatNumber(invoiceBoxes) : '—'} />
+          <MetricTile label="Invoice Weight" value={invoiceWeight > 0 ? formatKg(invoiceWeight) : '—'} />
+        </div>
+
+        {scannedBoxes === 0 && scanSkipApproved ? (
+          <div className="flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+            <PackageCheck className="h-4 w-4" />
+            Box scanning was skipped for this entry (approved by admin).
+          </div>
+        ) : null}
+
+        {invoiceItems.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[560px] text-sm">
+              <thead className="border-b bg-muted/50">
+                <tr>
+                  <th className="p-2 text-left font-medium">Item</th>
+                  <th className="p-2 text-right font-medium">Invoice Qty</th>
+                  <th className="p-2 text-right font-medium">Boxes</th>
+                  <th className="p-2 text-right font-medium">Weight</th>
+                </tr>
+              </thead>
+              <tbody>
+                {invoiceItems.map((item, index) => {
+                  const weight = parsePositiveNumber(item.total_weight);
+                  const boxes = parsePositiveNumber(item.total_boxes);
+                  const qty = parsePositiveNumber(item.quantity);
+                  return (
+                    <tr key={`${item.id}-${index}`} className="border-b last:border-b-0">
+                      <td className="p-2">
+                        <div className="font-medium">{formatValue(item.item_code)}</div>
+                        <div className="max-w-[280px] truncate text-xs text-muted-foreground">
+                          {item.item_name || '-'}
+                        </div>
+                      </td>
+                      <td className="p-2 text-right tabular-nums">
+                        {qty > 0 ? [formatNumber(qty), item.uom].filter(Boolean).join(' ') : '-'}
+                      </td>
+                      <td className="p-2 text-right tabular-nums">{boxes > 0 ? formatNumber(boxes) : '-'}</td>
+                      <td className="p-2 text-right tabular-nums">{weight > 0 ? formatKg(weight) : '-'}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+
+        {scans.length > 0 ? (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <ClipboardList className="h-4 w-4" />
+              Scanned boxes ({scans.length})
+            </div>
+            <div className="max-h-64 overflow-auto rounded-md border">
+              <table className="w-full min-w-[560px] text-sm">
+                <thead className="sticky top-0 border-b bg-muted">
+                  <tr>
+                    <th className="p-2 text-left font-medium">Barcode</th>
+                    <th className="p-2 text-left font-medium">Item</th>
+                    <th className="p-2 text-left font-medium">Batch</th>
+                    <th className="p-2 text-right font-medium">Qty</th>
+                    <th className="p-2 text-right font-medium">Net Weight</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {scans.map((scan) => {
+                    const boxNetWeight = parsePositiveNumber(scan.net_weight);
+                    return (
+                      <tr key={scan.id} className="border-b last:border-b-0">
+                        <td className="p-2 font-mono text-xs">{scan.box_barcode}</td>
+                        <td className="p-2">{formatValue(scan.item_code)}</td>
+                        <td className="p-2">{formatValue(scan.batch_number)}</td>
+                        <td className="p-2 text-right tabular-nums">
+                          {[scan.quantity, scan.uom].filter(Boolean).join(' ') || '-'}
+                        </td>
+                        <td className="p-2 text-right tabular-nums">
+                          {boxNetWeight > 0 ? formatKg(boxNetWeight) : '-'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MetricTile({
+  label,
+  value,
+  hint,
+  emphasis,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className={cn('rounded-md border bg-muted/20 p-3', emphasis && 'border-primary/40 bg-primary/5')}>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+function getInvoiceItems(entry: SalesDispatchGateOut): SalesDispatchItem[] {
+  if (entry.items?.length) return entry.items;
+  return entry.documents?.flatMap((document) => document.items || []) || [];
+}
+
+function formatKg(value: number) {
+  return `${formatNumber(value)} kg`;
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat('en-IN', { maximumFractionDigits: 2 }).format(value);
 }
 
 function formatWeight(value?: string | number | null) {

--- a/src/modules/gate/pages/customerSalesFlow/SalesDispatchGatepassPage.tsx
+++ b/src/modules/gate/pages/customerSalesFlow/SalesDispatchGatepassPage.tsx
@@ -494,7 +494,11 @@ export default function SalesDispatchGatepassPage() {
               <ReadinessItem
                 label="Box Scanning"
                 ready={Boolean(readiness?.has_box_scans)}
-                detail={`${entry.box_scans?.length || 0} boxes`}
+                detail={
+                  readiness?.scan_skip_approved && !entry.box_scans?.length
+                    ? 'Skipped (approved)'
+                    : `${entry.box_scans?.length || 0} boxes`
+                }
               />
               <ReadinessItem label="SAP Items" ready={Boolean(readiness?.has_items)} />
 


### PR DESCRIPTION
- New `admin` module: Admin dashboard and a Docking -> Scan Skip Requests review queue (approve/reject), wired into routes, permissions, registry.
- Docking scan page: operators can request to skip box scanning (reason + dialog); a pending request hard-gates "Continue", approval unlocks it, rejection shows the reviewer note.
- Sidebar/MobileSidebar: optional per-nav-item badge; Admin shows a live pending scan-skip count.
- Sales-dispatch-out gross-weight step: live "Invoice vs Loaded Weight" comparison (net = gross - tare vs invoice weight, variance tolerance) and a "Docking Load" card with scanned boxes, per-box net weight, and invoice item weight breakdown.
- Gatepass page shows "Skipped (approved)" when box scanning was waived.