### PR TITLE
feat(docking): make box scanning optional for Jivo Beverages

### DIFF
--- a/src/modules/gate/api/salesDispatch/salesDispatch.api.ts
+++ b/src/modules/gate/api/salesDispatch/salesDispatch.api.ts
@@ -63,6 +63,12 @@ export interface SalesDispatchGatepassReadiness {
   has_box_scans: boolean;
   /** True when an admin-approved scan-skip request satisfies the box-scan requirement. */
   scan_skip_approved?: boolean;
+  /**
+   * True when box scanning is optional for this entry's company (e.g. Jivo Beverages).
+   * Operators can continue past the scan step and print the gatepass without scanning
+   * any box and without an admin scan-skip approval.
+   */
+  box_scan_optional?: boolean;
   has_weighment: boolean;
   has_items: boolean;
   has_bilty_details?: boolean;

--- a/src/modules/gate/pages/customerSalesFlow/SalesDispatchBarcodeScanPage.tsx
+++ b/src/modules/gate/pages/customerSalesFlow/SalesDispatchBarcodeScanPage.tsx
@@ -103,6 +103,10 @@ export default function SalesDispatchBarcodeScanPage() {
     GATE_PERMISSIONS.SALES_DISPATCH.EDIT,
   ]);
   const canRequestScanSkip = hasPermission(ADMIN_PERMISSIONS.DOCKING.REQUEST_SCAN_SKIP);
+  // Some companies (e.g. Jivo Beverages) don't scan boxes at the factory at all, so box
+  // scanning is optional for them: operators can continue without scanning and without
+  // the admin scan-skip approval flow. Driven by the backend per the entry's company.
+  const isBoxScanOptional = entry?.gatepass_readiness?.box_scan_optional ?? false;
   const skipStatus = skipRequest?.status ?? null;
   const isSkipApproved = skipStatus === 'APPROVED';
   const isSkipPending = skipStatus === 'PENDING';
@@ -203,7 +207,7 @@ export default function SalesDispatchBarcodeScanPage() {
       setError('Docking details not found.');
       return;
     }
-    if (scans.length === 0 && !isSkipApproved) {
+    if (scans.length === 0 && !isSkipApproved && !isBoxScanOptional) {
       if (isSkipPending) {
         setError(
           'Box scanning skip is awaiting admin approval. You can continue once it is approved.',
@@ -281,17 +285,21 @@ export default function SalesDispatchBarcodeScanPage() {
         itemSummary={entry.item_summary}
       />
 
-      <ScanSkipPanel
-        skipRequest={skipRequest}
-        canRequest={canRequestScanSkip && !isReadOnly && canEditDocking}
-        hasScans={scans.length > 0}
-        isSubmitting={createSkipRequest.isPending}
-        onRequest={() => {
-          setSkipReason('');
-          setSkipError('');
-          setIsSkipDialogOpen(true);
-        }}
-      />
+      {isBoxScanOptional ? (
+        <ScanOptionalPanel />
+      ) : (
+        <ScanSkipPanel
+          skipRequest={skipRequest}
+          canRequest={canRequestScanSkip && !isReadOnly && canEditDocking}
+          hasScans={scans.length > 0}
+          isSubmitting={createSkipRequest.isPending}
+          onRequest={() => {
+            setSkipReason('');
+            setSkipError('');
+            setIsSkipDialogOpen(true);
+          }}
+        />
+      )}
 
       <section className="grid gap-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
         <Card className="overflow-hidden">
@@ -701,6 +709,21 @@ function ScanMetric({ label, value }: { label: string; value: string }) {
     <div className="rounded-md border bg-muted/20 p-3">
       <p className="text-xs text-muted-foreground">{label}</p>
       <p className="mt-1 text-xl font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function ScanOptionalPanel() {
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-sky-200 bg-sky-50 p-4 text-sky-900">
+      <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0" />
+      <div className="space-y-1">
+        <p className="font-medium">Box scanning is optional</p>
+        <p className="text-sm">
+          Boxes are not scanned at the factory for this company. You can continue to attachments
+          without scanning. You may still scan boxes below if you want to record them.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/modules/gate/pages/customerSalesFlow/SalesDispatchGatepassPage.tsx
+++ b/src/modules/gate/pages/customerSalesFlow/SalesDispatchGatepassPage.tsx
@@ -495,9 +495,11 @@ export default function SalesDispatchGatepassPage() {
                 label="Box Scanning"
                 ready={Boolean(readiness?.has_box_scans)}
                 detail={
-                  readiness?.scan_skip_approved && !entry.box_scans?.length
-                    ? 'Skipped (approved)'
-                    : `${entry.box_scans?.length || 0} boxes`
+                  readiness?.box_scan_optional && !entry.box_scans?.length
+                    ? 'Not required'
+                    : readiness?.scan_skip_approved && !entry.box_scans?.length
+                      ? 'Skipped (approved)'
+                      : `${entry.box_scans?.length || 0} boxes`
                 }
               />
               <ReadinessItem label="SAP Items" ready={Boolean(readiness?.has_items)} />


### PR DESCRIPTION
Companies flagged box-scan-optional by the backend (default JIVO_BEVERAGES) can continue past the docking scan step without scanning boxes and without the admin scan-skip approval flow. The scan page shows an informational notice instead of the approval panel, and the gatepass readiness shows "Not required". All other companies keep the scan + approval requirement unchanged.