### PR TITLE
feat(sales-dispatch): operator-entered challan weight on gate-out

### DIFF
--- a/src/config/constants/api.constants.ts
+++ b/src/config/constants/api.constants.ts
@@ -118,6 +118,8 @@ export const API_ENDPOINTS = {
       `/gate-core/sales-dispatch/${id}/gatepass/reprint/`,
     SALES_DISPATCH_GATEPASS_PRINTS: (id: number) =>
       `/gate-core/sales-dispatch/${id}/gatepass/prints/`,
+    SALES_DISPATCH_CHALLAN_WEIGHT: (id: number) =>
+      `/gate-core/sales-dispatch/${id}/challan-weight/`,
     SALES_DISPATCH_COMMIT_PRINT: (id: number) => `/gate-core/sales-dispatch/${id}/commit-print/`,
     SALES_DISPATCH_MARK_DISPATCHED: (id: number) => `/gate-core/sales-dispatch/${id}/dispatch/`,
     SALES_DISPATCH_REJECT: (id: number) => `/gate-core/sales-dispatch/${id}/reject/`,

--- a/src/modules/gate/api/salesDispatch/salesDispatch.api.ts
+++ b/src/modules/gate/api/salesDispatch/salesDispatch.api.ts
@@ -214,6 +214,11 @@ export interface SalesDispatchGateOut {
   total_litres?: string | null;
   total_boxes?: string | null;
   total_weight?: string | null;
+  /** Operator-entered challan weight; comparison reference when SAP total_weight is missing/wrong. */
+  challan_weight?: string | null;
+  challan_weight_at?: string | null;
+  challan_weight_by?: number | null;
+  challan_weight_by_name?: string | null;
   vehicle_no: string;
   transporter_name?: string;
   transporter_gstin?: string;
@@ -477,6 +482,11 @@ export interface SalesDispatchReasonRequest {
   reason: string;
 }
 
+export interface SalesDispatchChallanWeightRequest {
+  /** Pass null to clear the operator value and fall back to the SAP document weight. */
+  challan_weight: number | null;
+}
+
 function buildQuery(params?: Record<string, string | number | undefined>) {
   const queryParams = new URLSearchParams();
 
@@ -666,6 +676,17 @@ export const salesDispatchApi = {
   async gatepassPrintHistory(id: number): Promise<SalesDispatchGatepassPrintLog[]> {
     const response = await apiClient.get<SalesDispatchGatepassPrintLog[]>(
       API_ENDPOINTS.GATE_CORE.SALES_DISPATCH_GATEPASS_PRINTS(id),
+    );
+    return response.data;
+  },
+
+  async setChallanWeight(
+    id: number,
+    data: SalesDispatchChallanWeightRequest,
+  ): Promise<SalesDispatchGateOut> {
+    const response = await apiClient.post<SalesDispatchGateOut>(
+      API_ENDPOINTS.GATE_CORE.SALES_DISPATCH_CHALLAN_WEIGHT(id),
+      data,
     );
     return response.data;
   },

--- a/src/modules/gate/api/salesDispatch/salesDispatch.queries.ts
+++ b/src/modules/gate/api/salesDispatch/salesDispatch.queries.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
+  salesDispatchApi,
   type SalesDispatchAttachmentUploadRequest,
   type SalesDispatchBoxScanRequest,
+  type SalesDispatchChallanWeightRequest,
   type SalesDispatchCreateRequest,
   type SalesDispatchDocumentParams,
   type SalesDispatchDocumentType,
@@ -14,7 +16,6 @@ import {
   type SalesDispatchReasonRequest,
   type SalesDispatchReportParams,
   type SalesDispatchUpdateRequest,
-  salesDispatchApi,
 } from './salesDispatch.api';
 
 export const SALES_DISPATCH_QUERY_KEYS = {
@@ -238,6 +239,16 @@ export function useSalesDispatchGatepassPrintHistory(id?: number | null) {
     queryKey: SALES_DISPATCH_QUERY_KEYS.gatepassPrintHistory(id),
     queryFn: () => salesDispatchApi.gatepassPrintHistory(id as number),
     enabled: Boolean(id),
+  });
+}
+
+export function useSetSalesDispatchChallanWeight() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: SalesDispatchChallanWeightRequest }) =>
+      salesDispatchApi.setChallanWeight(id, data),
+    onSuccess: () => invalidateSalesDispatch(queryClient),
   });
 }
 

--- a/src/modules/gate/pages/customerSalesFlow/SalesDispatchDetailPage.tsx
+++ b/src/modules/gate/pages/customerSalesFlow/SalesDispatchDetailPage.tsx
@@ -16,9 +16,9 @@ import { toast } from 'sonner';
 import { GATE_PERMISSIONS } from '@/config/permissions';
 import { usePermission } from '@/core/auth';
 import {
+  type SalesDispatchBoxScan,
   type SalesDispatchGateOut,
   type SalesDispatchGateOutDocument,
-  type SalesDispatchBoxScan,
   type SalesDispatchItem,
   useCancelSalesDispatch,
   useRejectSalesDispatch,
@@ -43,16 +43,16 @@ import {
 import { getErrorMessage, resolveFileUrl } from '@/shared/utils';
 
 import {
+  getExpectedDispatchBoxes,
+  getExpectedDocumentBoxes,
+  getExpectedItemBoxes,
+} from './salesDispatchBoxCounts';
+import {
   formatDateTime,
   formatDocumentType,
   formatTimestamp,
   formatValue,
 } from './salesDispatchFlow.helpers';
-import {
-  getExpectedDispatchBoxes,
-  getExpectedDocumentBoxes,
-  getExpectedItemBoxes,
-} from './salesDispatchBoxCounts';
 import { getSalesDispatchRoutes, isSalesDispatchOutPath } from './salesDispatchRoutes';
 
 interface DetailDocument extends SalesDispatchGateOutDocument {
@@ -416,6 +416,14 @@ function DockingOverviewCard({
           <InfoItem label="Docked At" value={formatTimestamp(entry.docked_at)} />
           <InfoItem label="Box Scan Progress" value={formatScanProgress(entry)} />
           <InfoItem label="Invoice Weight" value={formatInvoiceWeightValue(entry.total_weight)} />
+          {hasDisplayValue(entry.challan_weight) ? (
+            <InfoItem
+              label="Challan Weight"
+              value={`${formatWeightValue(entry.challan_weight)}${
+                entry.challan_weight_by_name ? ` (by ${entry.challan_weight_by_name})` : ''
+              }`}
+            />
+          ) : null}
           <InfoItem label="Tare Weight" value={formatWeightValue(entry.tare_weight)} />
           {hasDisplayValue(entry.gross_weight) ? (
             <InfoItem label="Gross Weight" value={formatWeightValue(entry.gross_weight)} />

--- a/src/modules/gate/pages/customerSalesFlow/SalesDispatchGateOutWeighmentPage.tsx
+++ b/src/modules/gate/pages/customerSalesFlow/SalesDispatchGateOutWeighmentPage.tsx
@@ -10,6 +10,7 @@ import {
   type SalesDispatchItem,
   useCreateWeighment,
   useSalesDispatchByVehicleEntry,
+  useSetSalesDispatchChallanWeight,
   useWeighment,
   type Weighment,
 } from '@/modules/gate/api';
@@ -25,7 +26,15 @@ import {
   EMPTY_REQUIRED_WEIGHMENT,
   type RequiredWeighmentValues,
 } from '@/modules/gate/utils';
-import { Button, Card, CardContent, CardHeader, CardTitle } from '@/shared/components/ui';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from '@/shared/components/ui';
 import { cn, getErrorMessage } from '@/shared/utils';
 
 import { getExpectedDispatchBoxes, parsePositiveNumber } from './salesDispatchBoxCounts';
@@ -73,6 +82,7 @@ export default function SalesDispatchGateOutWeighmentPage() {
   const routes = getSalesDispatchRoutes(location.pathname);
   const { entryId, entryIdNumber } = useEntryId();
   const [values, setValues] = useState<RequiredWeighmentValues>(EMPTY_REQUIRED_WEIGHMENT);
+  const [challanWeight, setChallanWeightValue] = useState('');
   const [error, setError] = useState('');
 
   const {
@@ -88,6 +98,7 @@ export default function SalesDispatchGateOutWeighmentPage() {
     error: weighmentError,
   } = useWeighment(vehicleEntryId);
   const saveWeighment = useCreateWeighment(vehicleEntryId || 0);
+  const saveChallanWeight = useSetSalesDispatchChallanWeight();
 
   useEffect(() => {
     if (!weighment) return;
@@ -98,6 +109,15 @@ export default function SalesDispatchGateOutWeighmentPage() {
 
     return () => window.clearTimeout(timerId);
   }, [weighment]);
+
+  // Seed the input from any previously stored manual challan weight. Left blank when none,
+  // so an untouched field falls back to the SAP invoice weight rather than persisting a value.
+  useEffect(() => {
+    const stored = entry?.challan_weight;
+    const next = stored !== null && stored !== undefined && stored !== '' ? String(stored) : '';
+    const timerId = window.setTimeout(() => setChallanWeightValue(next), 0);
+    return () => window.clearTimeout(timerId);
+  }, [entry?.id, entry?.challan_weight]);
 
   const handleValueChange = (field: keyof RequiredWeighmentValues, value: string) => {
     setValues((current) => ({ ...current, [field]: value }));
@@ -120,6 +140,14 @@ export default function SalesDispatchGateOutWeighmentPage() {
       return;
     }
 
+    if (challanWeight.trim() !== '') {
+      const challanNum = Number(challanWeight);
+      if (!Number.isFinite(challanNum) || challanNum < 0) {
+        setError('Enter a valid challan weight, or leave it blank to use the SAP invoice weight.');
+        return;
+      }
+    }
+
     const payload: CreateWeighmentRequest = {
       gross_weight: Number(values.grossWeight),
       tare_weight: Number(values.tareWeight),
@@ -133,6 +161,18 @@ export default function SalesDispatchGateOutWeighmentPage() {
     }
 
     try {
+      const desiredChallan = challanWeight.trim() === '' ? null : Number(challanWeight);
+      const storedChallan = toFiniteNumber(entry.challan_weight);
+      const challanChanged =
+        desiredChallan === null
+          ? storedChallan !== null
+          : storedChallan === null || Math.abs(desiredChallan - storedChallan) > 1e-9;
+      if (challanChanged) {
+        await saveChallanWeight.mutateAsync({
+          id: entry.id,
+          data: { challan_weight: desiredChallan },
+        });
+      }
       await saveWeighment.mutateAsync(payload);
       await refetchEntry();
       toast.success('Gross weight saved');
@@ -184,13 +224,20 @@ export default function SalesDispatchGateOutWeighmentPage() {
   );
   const expectedBoxes = getExpectedDispatchBoxes(entry);
   const invoiceItems = getInvoiceItems(entry);
-  const invoiceWeight = parsePositiveNumber(entry.total_weight);
+  const sapInvoiceWeight = parsePositiveNumber(entry.total_weight);
   const invoiceBoxes = parsePositiveNumber(entry.total_boxes);
   const scanSkipApproved = Boolean(entry.gatepass_readiness?.scan_skip_approved);
+
+  const enteredChallanWeight = toFiniteNumber(challanWeight);
+  const isManualChallanWeight = enteredChallanWeight !== null && enteredChallanWeight > 0;
+  // The operator-entered challan weight wins; fall back to the SAP invoice weight when blank.
+  const effectiveChallanWeight = isManualChallanWeight ? enteredChallanWeight : sapInvoiceWeight;
 
   const grossNum = toFiniteNumber(values.grossWeight);
   const tareNum = toFiniteNumber(values.tareWeight);
   const netWeight = grossNum !== null && tareNum !== null ? grossNum - tareNum : null;
+
+  const isSaving = saveWeighment.isPending || saveChallanWeight.isPending;
 
   return (
     <div className="space-y-6 pb-6">
@@ -242,12 +289,25 @@ export default function SalesDispatchGateOutWeighmentPage() {
       <RequiredWeighmentForm
         values={values}
         onChange={handleValueChange}
-        disabled={saveWeighment.isPending}
+        disabled={isSaving}
         requiredFields={{ grossWeight: true, tareWeight: true }}
       />
 
+      <ChallanWeightCard
+        value={challanWeight}
+        onChange={(next) => {
+          setChallanWeightValue(next);
+          setError('');
+        }}
+        sapInvoiceWeight={sapInvoiceWeight}
+        enteredBy={entry.challan_weight_by_name}
+        enteredAt={entry.challan_weight_at}
+        disabled={isSaving}
+      />
+
       <WeightCheckCard
-        invoiceWeight={invoiceWeight}
+        challanWeight={effectiveChallanWeight}
+        isManual={isManualChallanWeight}
         gross={grossNum}
         tare={tareNum}
         net={netWeight}
@@ -260,7 +320,7 @@ export default function SalesDispatchGateOutWeighmentPage() {
         scannedNetWeight={scannedNetWeight}
         expectedBoxes={expectedBoxes}
         invoiceItems={invoiceItems}
-        invoiceWeight={invoiceWeight}
+        invoiceWeight={sapInvoiceWeight}
         invoiceBoxes={invoiceBoxes}
         scanSkipApproved={scanSkipApproved}
       />
@@ -269,8 +329,8 @@ export default function SalesDispatchGateOutWeighmentPage() {
         onPrevious={() => navigate(routes.detail(entry.id))}
         onCancel={() => navigate(routes.dashboard)}
         onNext={handleNext}
-        isSaving={saveWeighment.isPending}
-        nextLabel={saveWeighment.isPending ? 'Saving...' : 'Save and Continue to Gate Out'}
+        isSaving={isSaving}
+        nextLabel={isSaving ? 'Saving...' : 'Save and Continue to Gate Out'}
       />
     </div>
   );
@@ -303,21 +363,81 @@ function getVarianceTone(pct: number | null): keyof typeof VARIANCE_TONE {
   return 'bad';
 }
 
+function ChallanWeightCard({
+  value,
+  onChange,
+  sapInvoiceWeight,
+  enteredBy,
+  enteredAt,
+  disabled,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  sapInvoiceWeight: number;
+  enteredBy?: string | null;
+  enteredAt?: string | null;
+  disabled?: boolean;
+}) {
+  const hasSapWeight = sapInvoiceWeight > 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FileText className="h-5 w-5" />
+          Challan Weight
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Enter the weight from the delivery challan to check the loaded net weight against it. Use
+          this when the SAP invoice weight is missing or wrong. Leave it blank to compare against the
+          SAP invoice weight.
+        </p>
+        <div className="grid gap-2 sm:max-w-xs">
+          <Label htmlFor="challan-weight">Challan Weight (kg)</Label>
+          <Input
+            id="challan-weight"
+            type="number"
+            inputMode="decimal"
+            min={0}
+            step="any"
+            value={value}
+            disabled={disabled}
+            onChange={(event) => onChange(event.target.value)}
+            placeholder={hasSapWeight ? `SAP invoice: ${formatNumber(sapInvoiceWeight)}` : 'e.g. 2450'}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {hasSapWeight
+            ? `SAP invoice weight: ${formatKg(sapInvoiceWeight)}.`
+            : 'This SAP invoice has no weight.'}
+          {enteredBy
+            ? ` Last set by ${enteredBy}${enteredAt ? ` on ${formatTimestamp(enteredAt)}` : ''}.`
+            : ''}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
 function WeightCheckCard({
-  invoiceWeight,
+  challanWeight,
+  isManual,
   gross,
   tare,
   net,
 }: {
-  invoiceWeight: number;
+  challanWeight: number;
+  isManual: boolean;
   gross: number | null;
   tare: number | null;
   net: number | null;
 }) {
-  const hasInvoiceWeight = invoiceWeight > 0;
-  const variance = net !== null && hasInvoiceWeight ? net - invoiceWeight : null;
+  const hasChallanWeight = challanWeight > 0;
+  const variance = net !== null && hasChallanWeight ? net - challanWeight : null;
   const variancePct =
-    variance !== null && hasInvoiceWeight ? (variance / invoiceWeight) * 100 : null;
+    variance !== null && hasChallanWeight ? (variance / challanWeight) * 100 : null;
   const tone = getVarianceTone(variancePct);
 
   return (
@@ -325,15 +445,15 @@ function WeightCheckCard({
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Scale className="h-5 w-5" />
-          Invoice vs Loaded Weight
+          Challan vs Loaded Weight
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
           <MetricTile
-            label="Invoice Weight"
-            value={hasInvoiceWeight ? formatKg(invoiceWeight) : 'Not on invoice'}
-            hint="Expected product weight"
+            label="Challan Weight"
+            value={hasChallanWeight ? formatKg(challanWeight) : 'Not set'}
+            hint={isManual ? 'Manually entered' : 'From SAP invoice'}
           />
           <MetricTile
             label="Gross Weight"
@@ -355,11 +475,12 @@ function WeightCheckCard({
 
         {net === null ? (
           <p className="text-sm text-muted-foreground">
-            Enter gross and tare weight to compare the loaded net weight against the invoice.
+            Enter gross and tare weight to compare the loaded net weight against the challan.
           </p>
-        ) : !hasInvoiceWeight ? (
+        ) : !hasChallanWeight ? (
           <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
-            This invoice has no weight to compare against. Net loaded weight is {formatKg(net)}.
+            No challan or invoice weight to compare against. Enter a challan weight above. Net loaded
+            weight is {formatKg(net)}.
           </div>
         ) : (
           <div
@@ -370,7 +491,7 @@ function WeightCheckCard({
           >
             <span className="font-medium">{VARIANCE_TONE[tone].label}</span>
             <span>
-              Net {formatKg(net)} vs Invoice {formatKg(invoiceWeight)} ·{' '}
+              Net {formatKg(net)} vs Challan {formatKg(challanWeight)} ·{' '}
               <span className="font-semibold">
                 {variance !== null && variance >= 0 ? '+' : ''}
                 {variance !== null ? formatKg(variance) : '—'}


### PR DESCRIPTION
Let the gate operator enter a challan weight on the gate-out weighment page and compare the loaded net weight against it, falling back to the SAP invoice weight when blank. Surfaces who set it on the detail page. Advisory only — no new blocks.