### PR TITLE
feat(dispatch-linking): lock vehicle linking after empty-in; unlink + empty-out release

### DIFF
--- a/src/modules/dashboards/dispatch-plans/types/dispatch-plans.types.ts
+++ b/src/modules/dashboards/dispatch-plans/types/dispatch-plans.types.ts
@@ -31,6 +31,7 @@ export interface DispatchPlan {
   transporter_id: number | null;
   driver_id: number | null;
   linked_vehicle_entry_id: number | null;
+  is_vehicle_link_locked: boolean;
   booking_status: DispatchPlanStatus;
   dispatch_date: string | null;
   priority: string;

--- a/src/modules/gate/api/emptyVehicleOut/emptyVehicleOut.api.ts
+++ b/src/modules/gate/api/emptyVehicleOut/emptyVehicleOut.api.ts
@@ -14,6 +14,9 @@ export interface EmptyVehicleEligibleEntry {
   driver_name: string;
   driver_mobile: string;
   remarks?: string;
+  // Side effects of marking this vehicle out empty.
+  release_invoice_count: number;
+  release_cancels_docking: boolean;
 }
 
 export interface EmptyVehicleGateOutEntry {

--- a/src/modules/gate/pages/emptyVehicleOutPages/EmptyVehicleOutNewPage.tsx
+++ b/src/modules/gate/pages/emptyVehicleOutPages/EmptyVehicleOutNewPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, LogOut, RefreshCw, ShieldCheck, Truck } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, LogOut, RefreshCw, ShieldCheck, Truck } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -20,7 +20,10 @@ import {
   Textarea,
 } from '@/shared/components/ui';
 
-import { writeEmptyVehicleOutDraft } from './emptyVehicleOutDraft.storage';
+import {
+  buildEmptyOutSideEffectMessage,
+  writeEmptyVehicleOutDraft,
+} from './emptyVehicleOutDraft.storage';
 
 const ENTRY_TYPE_LABELS: Record<string, string> = {
   RAW_MATERIAL: 'Raw Material',
@@ -117,6 +120,12 @@ export default function EmptyVehicleOutNewPage() {
       eligibleEntries.find((entry) => String(entry.id) === selectedEntryId),
     [eligibleEntries, selectedEntryId, selectedEntrySnapshot],
   );
+  const sideEffectMessage = selectedEntry
+    ? buildEmptyOutSideEffectMessage(
+        selectedEntry.release_invoice_count,
+        selectedEntry.release_cancels_docking,
+      )
+    : null;
 
   const handleSubmit = async () => {
     if (!selectedEntry) {
@@ -148,6 +157,8 @@ export default function EmptyVehicleOutNewPage() {
       outTime,
       securityName,
       remarks,
+      releaseInvoiceCount: selectedEntry.release_invoice_count,
+      releaseCancelsDocking: selectedEntry.release_cancels_docking,
     });
 
     toast.success('Vehicle details saved');
@@ -303,6 +314,13 @@ export default function EmptyVehicleOutNewPage() {
                 </div>
               </CardContent>
             </Card>
+          )}
+
+          {sideEffectMessage && (
+            <div className="flex items-start gap-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{sideEffectMessage}</span>
+            </div>
           )}
 
           {formError && <p className="text-sm text-destructive">{formError}</p>}

--- a/src/modules/gate/pages/emptyVehicleOutPages/EmptyVehicleOutWeighmentPage.tsx
+++ b/src/modules/gate/pages/emptyVehicleOutPages/EmptyVehicleOutWeighmentPage.tsx
@@ -27,6 +27,7 @@ import { Button, Card, CardContent, CardHeader, CardTitle } from '@/shared/compo
 import { getErrorMessage, isNotFoundError as checkNotFoundError } from '@/shared/utils';
 
 import {
+  buildEmptyOutSideEffectMessage,
   clearEmptyVehicleOutDraft,
   type EmptyVehicleOutDraft,
   readEmptyVehicleOutDraft,
@@ -160,6 +161,11 @@ export default function EmptyVehicleOutWeighmentPage() {
       ? 'No existing weighment found. Fill it before completing gate out.'
       : '';
 
+  const sideEffectMessage = buildEmptyOutSideEffectMessage(
+    draft.releaseInvoiceCount ?? 0,
+    draft.releaseCancelsDocking ?? false,
+  );
+
   return (
     <div className="space-y-6 pb-6">
       <StepHeader
@@ -250,6 +256,15 @@ export default function EmptyVehicleOutWeighmentPage() {
           )}
         </CardContent>
       </Card>
+
+      {sideEffectMessage && (
+        <div className="flex items-start gap-3 rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+          <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+          <span>
+            {sideEffectMessage} This happens when you complete the gate out.
+          </span>
+        </div>
+      )}
 
       <StepFooter
         onPrevious={() => navigate('/gate/empty-vehicle-out/new')}

--- a/src/modules/gate/pages/emptyVehicleOutPages/emptyVehicleOutDraft.storage.ts
+++ b/src/modules/gate/pages/emptyVehicleOutPages/emptyVehicleOutDraft.storage.ts
@@ -12,6 +12,8 @@ export interface EmptyVehicleOutDraft {
   outTime: string;
   securityName: string;
   remarks: string;
+  releaseInvoiceCount: number;
+  releaseCancelsDocking: boolean;
 }
 
 export function readEmptyVehicleOutDraft(): EmptyVehicleOutDraft | null {
@@ -31,4 +33,24 @@ export function writeEmptyVehicleOutDraft(draft: EmptyVehicleOutDraft) {
 
 export function clearEmptyVehicleOutDraft() {
   window.localStorage.removeItem(EMPTY_VEHICLE_OUT_DRAFT_KEY);
+}
+
+/**
+ * Human-readable summary of what marking this vehicle out empty will do to its
+ * dispatch bookings. Returns null when there are no side effects to warn about.
+ */
+export function buildEmptyOutSideEffectMessage(
+  invoiceCount: number,
+  cancelsDocking: boolean,
+): string | null {
+  if (invoiceCount <= 0 && !cancelsDocking) return null;
+
+  const parts: string[] = [];
+  if (cancelsDocking) parts.push('cancel the docked gate-out entry');
+  if (invoiceCount > 0) {
+    parts.push(
+      `release ${invoiceCount} invoice${invoiceCount === 1 ? '' : 's'} for re-planning`,
+    );
+  }
+  return `Marking this vehicle out empty will ${parts.join(' and ')}.`;
 }

--- a/src/modules/vehicle-management/api/dispatch-linking.api.ts
+++ b/src/modules/vehicle-management/api/dispatch-linking.api.ts
@@ -89,4 +89,18 @@ export const dispatchLinkingApi = {
   async linkVehicle(docEntry: number, payload: DispatchVehicleLinkPayload) {
     return dispatchPlansApi.updatePlan(docEntry, payload);
   },
+
+  // Clear a booking so the vehicle can be re-assigned to another invoice.
+  // Resets the plan to PENDING and drops the transport assignment; the backend
+  // wipes the snapshot fields (vehicle_no, transporter/driver details) once the
+  // ids are explicitly nulled.
+  async unlinkVehicle(docEntry: number) {
+    return dispatchPlansApi.updatePlan(docEntry, {
+      vehicle_id: null,
+      transporter_id: null,
+      driver_id: null,
+      linked_vehicle_entry_id: null,
+      booking_status: 'PENDING',
+    });
+  },
 };

--- a/src/modules/vehicle-management/api/dispatch-linking.queries.ts
+++ b/src/modules/vehicle-management/api/dispatch-linking.queries.ts
@@ -32,6 +32,12 @@ export function useDispatchLinkingPlans(
   });
 }
 
+function invalidateDispatchLinkingQueries(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: DISPATCH_LINKING_QUERY_KEYS.all });
+  queryClient.invalidateQueries({ queryKey: ['dispatch-plans'] });
+  queryClient.invalidateQueries({ queryKey: ['salesDispatchGateOuts'] });
+}
+
 export function useLinkDispatchVehicle() {
   const queryClient = useQueryClient();
 
@@ -43,10 +49,16 @@ export function useLinkDispatchVehicle() {
       docEntry: number;
       payload: DispatchVehicleLinkPayload;
     }) => dispatchLinkingApi.linkVehicle(docEntry, payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: DISPATCH_LINKING_QUERY_KEYS.all });
-      queryClient.invalidateQueries({ queryKey: ['dispatch-plans'] });
-      queryClient.invalidateQueries({ queryKey: ['salesDispatchGateOuts'] });
-    },
+    onSuccess: () => invalidateDispatchLinkingQueries(queryClient),
+  });
+}
+
+export function useUnlinkDispatchVehicle() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ docEntry }: { docEntry: number }) =>
+      dispatchLinkingApi.unlinkVehicle(docEntry),
+    onSuccess: () => invalidateDispatchLinkingQueries(queryClient),
   });
 }

--- a/src/modules/vehicle-management/api/index.ts
+++ b/src/modules/vehicle-management/api/index.ts
@@ -3,4 +3,5 @@ export {
   DISPATCH_LINKING_QUERY_KEYS,
   useDispatchLinkingPlans,
   useLinkDispatchVehicle,
+  useUnlinkDispatchVehicle,
 } from './dispatch-linking.queries';

--- a/src/modules/vehicle-management/components/DispatchLinkingSheet.tsx
+++ b/src/modules/vehicle-management/components/DispatchLinkingSheet.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Plus, Save } from 'lucide-react';
+import { Loader2, Plus, Save, Unlink } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { DispatchBill } from '@/modules/dashboards/dispatch-plans/types';
@@ -26,8 +26,10 @@ interface DispatchLinkingSheetProps {
   selectedBills: DispatchBill[];
   open: boolean;
   isSaving: boolean;
+  isUnlinking: boolean;
   onOpenChange: (open: boolean) => void;
   onSave: (docEntry: number, payload: DispatchVehicleLinkPayload) => Promise<void>;
+  onUnlink: (docEntry: number) => Promise<void>;
 }
 
 interface FormState {
@@ -175,11 +177,14 @@ export function DispatchLinkingSheet({
   selectedBills,
   open,
   isSaving,
+  isUnlinking,
   onOpenChange,
   onSave,
+  onUnlink,
 }: DispatchLinkingSheetProps) {
   const [form, setForm] = useState<FormState>(() => formFromBill(bill));
   const [formError, setFormError] = useState('');
+  const [confirmingUnlink, setConfirmingUnlink] = useState(false);
   const formErrors = useMemo(
     () => (formError ? { 'dispatch-linking-form-error': { message: formError } } : {}),
     [formError],
@@ -222,11 +227,21 @@ export function DispatchLinkingSheet({
     // eslint-disable-next-line react-hooks/set-state-in-effect -- Sheet form must follow the selected bill.
     setForm(formFromBill(bill));
     setFormError('');
+    setConfirmingUnlink(false);
   }, [bill, open]);
 
   function updateField<K extends keyof FormState>(field: K, value: FormState[K]) {
     setForm((prev) => ({ ...prev, [field]: value }));
     setFormError('');
+  }
+
+  const canUnlink = Boolean(
+    bill && !isBatchLink && bill.plan.vehicle_id && !bill.plan.is_vehicle_link_locked,
+  );
+
+  async function handleUnlink() {
+    if (!bill) return;
+    await onUnlink(bill.doc_entry);
   }
 
   function handleVehicleSelect(vehicle: VehicleSelection) {
@@ -436,18 +451,67 @@ export function DispatchLinkingSheet({
             />
           </div>
 
-          <SheetFooter className="mt-auto border-t pt-4">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isSaving}>
-              {isSaving ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          <SheetFooter className="mt-auto flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+            {canUnlink ? (
+              confirmingUnlink ? (
+                <div className="flex w-full flex-col gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 sm:w-auto sm:flex-row sm:items-center">
+                  <span className="text-sm text-destructive">
+                    Unlink this vehicle and set the booking back to Pending?
+                  </span>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setConfirmingUnlink(false)}
+                      disabled={isUnlinking}
+                    >
+                      Keep
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="sm"
+                      onClick={handleUnlink}
+                      disabled={isUnlinking}
+                    >
+                      {isUnlinking ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Unlink className="mr-2 h-4 w-4" />
+                      )}
+                      Confirm Unlink
+                    </Button>
+                  </div>
+                </div>
               ) : (
-                <Save className="mr-2 h-4 w-4" />
-              )}
-              Save Link
-            </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => setConfirmingUnlink(true)}
+                  disabled={isSaving || isUnlinking}
+                >
+                  <Unlink className="mr-2 h-4 w-4" />
+                  Unlink Vehicle
+                </Button>
+              )
+            ) : (
+              <span />
+            )}
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSaving || isUnlinking}>
+                {isSaving ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="mr-2 h-4 w-4" />
+                )}
+                Save Link
+              </Button>
+            </div>
           </SheetFooter>
         </form>
       </SheetContent>

--- a/src/modules/vehicle-management/components/DispatchLinkingTable.tsx
+++ b/src/modules/vehicle-management/components/DispatchLinkingTable.tsx
@@ -1,4 +1,4 @@
-import { Link2, Loader2 } from 'lucide-react';
+import { Link2, Loader2, Lock } from 'lucide-react';
 
 import { StatusBadge } from '@/modules/dashboards/dispatch-plans/components';
 import type { DispatchBill } from '@/modules/dashboards/dispatch-plans/types';
@@ -88,6 +88,7 @@ export function DispatchLinkingTable({
           <tbody>
             {bills.map((bill) => {
               const selected = selectedDocEntries.has(bill.doc_entry);
+              const linkLocked = bill.plan.is_vehicle_link_locked;
               return (
                 <tr
                   key={bill.doc_entry}
@@ -101,7 +102,7 @@ export function DispatchLinkingTable({
                   <td className="px-4 py-3 align-top">
                     <Checkbox
                       checked={selected}
-                      disabled={!canEdit}
+                      disabled={!canEdit || linkLocked}
                       aria-label={`Select invoice ${bill.doc_num}`}
                       onCheckedChange={() => onToggleSelection(bill)}
                     />
@@ -172,15 +173,26 @@ export function DispatchLinkingTable({
                       type="button"
                       variant={bill.plan.vehicle_id ? 'outline' : 'default'}
                       size="sm"
-                      disabled={!canEdit}
+                      disabled={!canEdit || linkLocked}
+                      title={
+                        linkLocked
+                          ? 'Empty vehicle gate-in is complete. To re-plan, complete an empty-vehicle-out for this vehicle first.'
+                          : undefined
+                      }
                       onClick={() => onLink(bill)}
                     >
-                      <Link2 className="mr-2 h-4 w-4" />
-                      {selectedDocEntries.size > 1 && selected
-                        ? 'Link Selected'
-                        : bill.plan.vehicle_id
-                          ? 'Edit Link'
-                          : 'Link'}
+                      {linkLocked ? (
+                        <Lock className="mr-2 h-4 w-4" />
+                      ) : (
+                        <Link2 className="mr-2 h-4 w-4" />
+                      )}
+                      {linkLocked
+                        ? 'Locked'
+                        : selectedDocEntries.size > 1 && selected
+                          ? 'Link Selected'
+                          : bill.plan.vehicle_id
+                            ? 'Edit Link'
+                            : 'Link'}
                     </Button>
                   </td>
                 </tr>

--- a/src/modules/vehicle-management/pages/DispatchVehicleLinkingPage.tsx
+++ b/src/modules/vehicle-management/pages/DispatchVehicleLinkingPage.tsx
@@ -17,7 +17,11 @@ import {
 } from '@/shared/components/ui';
 import { cn } from '@/shared/utils';
 
-import { useDispatchLinkingPlans, useLinkDispatchVehicle } from '../api';
+import {
+  useDispatchLinkingPlans,
+  useLinkDispatchVehicle,
+  useUnlinkDispatchVehicle,
+} from '../api';
 import { DispatchLinkingSheet, DispatchLinkingTable } from '../components';
 import type {
   DispatchLinkingBucket,
@@ -62,6 +66,7 @@ export default function DispatchVehicleLinkingPage() {
 
   const plansQuery = useDispatchLinkingPlans(effectiveFilters, currentCompany?.company_id);
   const linkMutation = useLinkDispatchVehicle();
+  const unlinkMutation = useUnlinkDispatchVehicle();
 
   const handleLink = (bill: DispatchBill) => {
     setSelectedBill(bill);
@@ -93,6 +98,18 @@ export default function DispatchVehicleLinkingPage() {
       setSelectedDocEntries(new Set());
     } catch {
       toast.error('Failed to link vehicle');
+    }
+  };
+
+  const handleUnlink = async (docEntry: number) => {
+    try {
+      await unlinkMutation.mutateAsync({ docEntry });
+      toast.success('Vehicle unlinked. The booking is back to Pending.');
+      setIsSheetOpen(false);
+      setSelectedBill(null);
+      setSelectedDocEntries(new Set());
+    } catch {
+      toast.error('Failed to unlink vehicle');
     }
   };
 
@@ -250,8 +267,10 @@ export default function DispatchVehicleLinkingPage() {
         selectedBills={selectedBills}
         open={isSheetOpen}
         isSaving={linkMutation.isPending}
+        isUnlinking={unlinkMutation.isPending}
         onOpenChange={setIsSheetOpen}
         onSave={handleSave}
+        onUnlink={handleUnlink}
       />
     </div>
   );


### PR DESCRIPTION
Companion to factory_app PR (same branch) - merge together. Lock vehicle linking once empty-vehicle-in is completed; add per-invoice Unlink action; surface empty-out side effects. ESLint clean; no new type errors.