### PR TITLE
fix(wms): stable location codes + name only stock-holding cells

### DIFF
--- a/src/modules/wms/__tests__/wms.areas.test.ts
+++ b/src/modules/wms/__tests__/wms.areas.test.ts
@@ -6,6 +6,7 @@ import {
   buildOccupancyIndex,
   codeForCell,
   isOutside,
+  makeCellPurpose,
   makePallet,
   makeWarehouseArea,
   makeWarehouseLocation,
@@ -205,6 +206,38 @@ describe('buildAreaCodeMap — continuous numbering that skips disabled cells', 
     const map = buildAreaCodeMap(wh({ areas: [area] }), [inside, outside]);
     expect(map.get(inside.id)).toBe('A-01');
     expect(map.get(outside.id)).toBeNull();
+  });
+
+  it('names only stock-holding cells, staying gapless across a non-storage cell', () => {
+    const area = makeWarehouseArea({
+      name: 'Main',
+      color: '#000',
+      startColumn: 0,
+      startRow: 0,
+      endColumn: 0,
+      endRow: 4,
+    });
+    const w = wh({ columns: 1, rows: 5, levels: 1, areas: [area] });
+    const path = makeCellPurpose('wh', { name: 'Walkway', color: '#64748b', holdsStock: false });
+    const rack = makeCellPurpose('wh', { name: 'Racking', color: '#22c55e', holdsStock: true });
+    const purposesById = new Map([
+      [path.id, path],
+      [rack.id, rack],
+    ]);
+    const cells = [
+      { ...loc(0, 0), purposeId: rack.id },
+      { ...loc(0, 1), purposeId: rack.id },
+      { ...loc(0, 2), purposeId: path.id }, // walkway — no name
+      { ...loc(0, 3), purposeId: rack.id },
+      { ...loc(0, 4) }, // no purpose → storage
+    ];
+    const map = buildAreaCodeMap(w, cells, purposesById);
+    const at = (r: number) => map.get(cells[r]!.id);
+    expect(at(0)).toBe('A-01');
+    expect(at(1)).toBe('A-02');
+    expect(at(2)).toBeNull(); // non-storage → no code
+    expect(at(3)).toBe('A-03'); // continues from A-02, NOT A-04
+    expect(at(4)).toBe('A-04');
   });
 
   it('numbers blocks that share a groupId continuously (one logical area)', () => {

--- a/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
+++ b/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
@@ -38,7 +38,6 @@ import {
   applyLocationDraft,
   axisLabel,
   boundingRect,
-  buildLocationCode,
   buildLocationsCsv,
   buildTemplate,
   findArea,
@@ -113,21 +112,9 @@ export default function WmsWarehouseEditorPage() {
         id: location.id,
         column: location.column,
         row: location.row,
-        // Full-grid view shows every cell's raw grid code (as before areas).
-        code:
-          showFullGrid && warehouse
-            ? buildLocationCode(
-                {
-                  columns: warehouse.columns,
-                  rows: warehouse.rows,
-                  levels: warehouse.levels,
-                  naming: warehouse.namingScheme,
-                },
-                location.column,
-                location.row,
-                location.level,
-              )
-            : location.code,
+        // The persisted code is the single source of truth, shown identically in
+        // both the areas view and the full grid — toggling never renumbers a cell.
+        code: location.code,
         // Purpose is the single colour axis for a cell.
         purposeColor: location.purposeId ? purposeById.get(location.purposeId)?.color ?? null : null,
         // Area is shown as an outline around its region, not a fill.
@@ -145,7 +132,7 @@ export default function WmsWarehouseEditorPage() {
         status: location.status,
       };
     });
-  }, [levelLocations, purposeById, areas, outsideIds, showFullGrid, warehouse],
+  }, [levelLocations, purposeById, areas, outsideIds, showFullGrid],
   );
 
   const selectedArray = useMemo(() => Array.from(selectedIds), [selectedIds]);
@@ -285,16 +272,26 @@ export default function WmsWarehouseEditorPage() {
     newPurposes: CellPurpose[],
   ) {
     const ids = new Set(propsTargets.map((location) => location.id));
+    // Purpose / enabled decide whether a cell is named at all (only stock-holding,
+    // enabled cells get a code), so those changes must renumber the layout —
+    // unless the user set a manual code in the same save, which we must not clobber.
+    const renumber =
+      (touched.has('purposeId') || touched.has('enabled')) &&
+      !touched.has('code') &&
+      !touched.has('barcode');
     void run(
       () =>
-        mutate((current) => ({
-          ...current,
-          // Persist any purposes created inline in the drawer.
-          purposes: newPurposes.length ? [...current.purposes, ...newPurposes] : current.purposes,
-          locations: current.locations.map((location) =>
-            ids.has(location.id) ? applyLocationDraft(location, draft, touched) : location,
-          ),
-        })),
+        mutate((current) => {
+          const next = {
+            ...current,
+            // Persist any purposes created inline in the drawer.
+            purposes: newPurposes.length ? [...current.purposes, ...newPurposes] : current.purposes,
+            locations: current.locations.map((location) =>
+              ids.has(location.id) ? applyLocationDraft(location, draft, touched) : location,
+            ),
+          };
+          return renumber ? rebuildWarehouseCodes(next) : next;
+        }),
       ids.size > 1 ? `Updated ${ids.size} locations.` : 'Location updated.',
     );
     setPropsOpen(false);

--- a/src/modules/wms/services/areas.ts
+++ b/src/modules/wms/services/areas.ts
@@ -9,8 +9,9 @@
  *
  * Pure and side-effect-free so it is trivial to unit-test and cheap to recompute.
  */
-import type { Warehouse, WarehouseArea, WarehouseLocation } from '../types';
+import type { CellPurpose, Warehouse, WarehouseArea, WarehouseLocation } from '../types';
 import { axisLabel, buildLocationCode } from './layout';
+import { locationHoldsStock } from './occupancy';
 
 /** Whether a grid cell lies within an area (corners inclusive). */
 export function areaContains(area: WarehouseArea, column: number, row: number): boolean {
@@ -122,13 +123,18 @@ export function rectsOverlap(
 }
 
 /**
- * Build the code for every location, area-aware and **skipping disabled cells**.
+ * Build the code for every location, area-aware and **numbering only cells that
+ * hold stock**.
  *
- * Within each area only enabled cells are numbered, consecutively: fully-disabled
- * rows and columns (walls, aisles) are skipped so codes stay gapless — e.g. the
- * cell after A-15 across a disabled band is A-16, not A-21. Disabled cells and
- * cells outside every area get `null` (no code). Each cell belongs to the first
- * area that contains it, so areas should not overlap.
+ * Within each area only cells that are enabled *and* whose purpose holds stock
+ * are numbered, consecutively: disabled cells and non-storage cells (paths,
+ * gates, cabins, obstacles) are skipped so codes stay gapless — e.g. the cell
+ * after A-15 across an aisle band is A-16, not A-21. Skipped cells and cells
+ * outside every area get `null` (no code). Each cell belongs to the first area
+ * that contains it, so areas should not overlap.
+ *
+ * Pass `purposesById` to honour per-cell purposes; without it every cell is
+ * treated as storage (legacy behaviour).
  *
  * Returns a Map from location id to its code (or null). Empty when no areas are
  * defined — the caller then falls back to whole-grid numbering.
@@ -136,6 +142,7 @@ export function rectsOverlap(
 export function buildAreaCodeMap(
   warehouse: Warehouse,
   locations: readonly WarehouseLocation[],
+  purposesById?: Map<string, CellPurpose>,
 ): Map<string, string | null> {
   const areas = warehouseAreas(warehouse);
   const result = new Map<string, string | null>();
@@ -158,20 +165,22 @@ export function buildAreaCodeMap(
     else byGroup.set(key, { area, cells: [location] });
   }
 
-  const isEnabled = (l: WarehouseLocation) => l.enabled !== false;
+  // A cell is numbered only when it is enabled AND actually holds stock —
+  // disabled cells and non-storage cells (paths, gates, cabins) carry no code.
+  const isCoded = (l: WarehouseLocation) => l.enabled !== false && locationHoldsStock(l, purposesById);
 
   for (const { area, cells } of byGroup.values()) {
-    const enabled = cells.filter(isEnabled);
-    // Counted rows/columns = those with at least one enabled cell (any level).
-    const rows = [...new Set(enabled.map((c) => c.row))].sort((a, b) => a - b);
-    const columns = [...new Set(enabled.map((c) => c.column))].sort((a, b) => a - b);
+    const coded = cells.filter(isCoded);
+    // Counted rows/columns = those with at least one coded cell (any level).
+    const rows = [...new Set(coded.map((c) => c.row))].sort((a, b) => a - b);
+    const columns = [...new Set(coded.map((c) => c.column))].sort((a, b) => a - b);
     const rowIndex = new Map(rows.map((r, i) => [r, i]));
     const colIndex = new Map(columns.map((c, i) => [c, i]));
     const prefix = (area.prefix || '').trim() || (naming.prefix || '').trim();
 
     for (const cell of cells) {
-      if (!isEnabled(cell)) {
-        result.set(cell.id, null); // disabled → no code
+      if (!isCoded(cell)) {
+        result.set(cell.id, null); // disabled or non-storage → no code
         continue;
       }
       const ci = colIndex.get(cell.column);

--- a/src/modules/wms/services/layoutOps.ts
+++ b/src/modules/wms/services/layoutOps.ts
@@ -12,6 +12,7 @@ import type { WmsId } from '../types';
 import { nowIso } from '../utils';
 import { buildAreaCodeMap, codeForCell, warehouseAreas } from './areas';
 import { makeWarehouseLocation } from './factories';
+import { locationHoldsStock } from './occupancy';
 import type { WarehouseBundle } from './warehouseIO';
 
 type Axis = 'column' | 'row' | 'level';
@@ -19,22 +20,26 @@ type Axis = 'column' | 'row' | 'level';
 /**
  * Recompute every location's code/barcode.
  *
- * With areas defined, each area is numbered from its corner, skipping disabled
- * cells so codes are gapless (see `buildAreaCodeMap`); cells outside every area
- * or disabled get a blank code. With no areas, the whole grid is numbered from
- * its origin (legacy behaviour).
+ * Only cells that hold stock are named. With areas defined, each area is
+ * numbered from its corner, skipping disabled and non-storage cells so codes are
+ * gapless (see `buildAreaCodeMap`); cells outside every area get a blank code.
+ * With no areas, the whole grid is numbered from its origin (legacy behaviour),
+ * still blanking non-storage cells (paths, gates, cabins).
  */
 function rebuildCodes(bundle: WarehouseBundle): WarehouseBundle {
   const { warehouse } = bundle;
   const timestamp = nowIso();
   const seen = new Set<string>();
+  const purposesById = new Map(bundle.purposes.map((purpose) => [purpose.id, purpose]));
   const codeMap = warehouseAreas(warehouse).length
-    ? buildAreaCodeMap(warehouse, bundle.locations)
+    ? buildAreaCodeMap(warehouse, bundle.locations, purposesById)
     : null;
   const locations = bundle.locations.map((location) => {
     const generated = codeMap
       ? codeMap.get(location.id) ?? null
-      : codeForCell(warehouse, location.column, location.row, location.level);
+      : locationHoldsStock(location, purposesById)
+        ? codeForCell(warehouse, location.column, location.row, location.level)
+        : null; // non-storage cell with no areas → no code
     if (generated == null) {
       return { ...location, code: '', barcode: '', updatedAt: timestamp };
     }


### PR DESCRIPTION
## Summary
Fixes two issues in the warehouse layout editor grid:

1. **Location codes changed when toggling "Full grid".** The editor stored each cell's real per-area code but the Full-grid view recomputed a *different* raw whole-grid code, so the same physical cell showed two codes. Both views now render the persisted `location.code` — toggling never renumbers a cell.
2. **Non-storage cells were still named.** Codes are now assigned only to enabled, stock-holding cells. Paths, gates, cabins, obstacles and outside-area cells get no code, and numbering stays gapless across them. Changing a cell's purpose/enabled state renumbers accordingly.

## Changes
- `services/areas.ts` — `buildAreaCodeMap` is purpose-aware (numbers only enabled + stock-holding cells, gapless).
- `services/layoutOps.ts` — `rebuildCodes` passes purposes through and blanks non-storage cells (areas and legacy no-areas paths).
- `pages/WmsWarehouseEditorPage.tsx` — always show `location.code`; renumber after a purpose/enabled change.
- `__tests__/wms.areas.test.ts` — new test locking in purpose-aware gapless numbering.

## Verification
- Full WMS suite: **134 tests pass**.
- `npm run build` succeeds.

> Note: also carries two prior unpushed WMS commits on this branch (area-aware editor grid, map header alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)