### PR TITLE
fix(wms): hide mismatched coordinate headers in full-grid view

### DIFF
--- a/src/modules/wms/components/WarehouseGrid.tsx
+++ b/src/modules/wms/components/WarehouseGrid.tsx
@@ -54,6 +54,9 @@ interface WarehouseGridProps {
   cells: GridCell[];
   /** When non-empty, global headers are hidden and area origins are badged. */
   areas?: GridArea[];
+  /** Force-hide the global coordinate headers even without areas (e.g. the
+   * full-grid view, where cells show area-relative codes the axes can't match). */
+  hideHeaders?: boolean;
   selectable?: boolean;
   selectedIds?: ReadonlySet<string>;
   onCellClick?: (cell: GridCell, shiftKey: boolean) => void;
@@ -70,6 +73,7 @@ export function WarehouseGrid({
   naming,
   cells,
   areas = [],
+  hideHeaders = false,
   selectable = false,
   selectedIds,
   onCellClick,
@@ -83,6 +87,9 @@ export function WarehouseGrid({
   }, [cells]);
 
   const hasAreas = areas.length > 0;
+  // Coordinate headers are shown only when they can match the cell codes: no
+  // areas (whole grid numbers from one origin) and not explicitly suppressed.
+  const headersShown = !hasAreas && !hideHeaders;
 
   const columnLabels = useMemo(
     () => Array.from({ length: columns }, (_, c) => axisLabel(naming.columnStyle, c, columns)),
@@ -121,15 +128,15 @@ export function WarehouseGrid({
     return map;
   }, [areas, cells, hasAreas]);
 
-  const gridTemplateColumns = hasAreas
-    ? `repeat(${columns}, minmax(2.75rem, 1fr))`
-    : `auto repeat(${columns}, minmax(2.75rem, 1fr))`;
+  const gridTemplateColumns = headersShown
+    ? `auto repeat(${columns}, minmax(2.75rem, 1fr))`
+    : `repeat(${columns}, minmax(2.75rem, 1fr))`;
 
   return (
     <div className="overflow-auto rounded-md border bg-muted/20 p-3">
       <div className="grid gap-1" style={{ gridTemplateColumns }}>
         {/* Header row: empty corner + column labels (only when headers match) */}
-        {!hasAreas && (
+        {headersShown && (
           <>
             <div />
             {columnLabels.map((label, c) => (
@@ -154,7 +161,7 @@ export function WarehouseGrid({
           <Row
             key={`row-${r}`}
             rowLabel={rowLabel}
-            showHeader={!hasAreas}
+            showHeader={headersShown}
             row={r}
             columns={columns}
             cellByPos={cellByPos}

--- a/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
+++ b/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
@@ -517,9 +517,11 @@ export default function WmsWarehouseEditorPage() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between gap-2">
           <CardTitle className="text-sm font-medium text-muted-foreground">
-            {!showFullGrid && areas.length > 0
-              ? 'Click to select · shift-click for a range · each area numbers from its ⌜ A-01 corner'
-              : 'Click to select · shift-click for a range · click a header for a column/row'}
+            {showFullGrid
+              ? 'Click to select · shift-click for a range · every cell shows its saved code'
+              : areas.length > 0
+                ? 'Click to select · shift-click for a range · each area numbers from its ⌜ A-01 corner'
+                : 'Click to select · shift-click for a range · click a header for a column/row'}
           </CardTitle>
           <div className="flex flex-wrap items-center gap-2">
             {areas.length > 0 ? (
@@ -553,6 +555,7 @@ export default function WmsWarehouseEditorPage() {
             naming={warehouse.namingScheme}
             cells={cells}
             areas={showFullGrid ? [] : areas}
+            hideHeaders={showFullGrid}
             selectable
             selectedIds={selectedIds}
             onCellClick={handleCellClick}


### PR DESCRIPTION
## Summary
Follow-up to #80. After location codes became stable across the areas view and the full grid, the full-grid view still rendered raw grid-coordinate headers (`A–H` / `01–05`) above cells that now carry area-relative codes (`A-01`…) — so the header `C` sat above a cell labeled `A-01`. Verified live in a browser.

## Fix
- `WarehouseGrid.tsx` — new `hideHeaders` prop; when set, the coordinate header row/column and its layout gutter are suppressed.
- `WmsWarehouseEditorPage.tsx` — passes `hideHeaders={showFullGrid}`; full-grid hint text updated to "every cell shows its saved code".

Now both views label cells only by their saved code — no conflicting coordinate axes.

## Verification
- Drove the real grid UI in headless Chrome: full grid renders codes-only, walkway unnamed, outside cells blank — no mismatched headers.
- Full WMS suite: **134 tests pass**. `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)