### PR TITLE
wms: non-storage plan areas + Labels pagination

### DIFF
--- a/src/modules/wms/__tests__/wms.warehouseGrid.test.tsx
+++ b/src/modules/wms/__tests__/wms.warehouseGrid.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type GridCell, WarehouseGrid } from '../components/WarehouseGrid';
+import { DEFAULT_NAMING_SCHEME } from '../services';
+
+/**
+ * A 3x2 grid: column A (storage, coded), column B is a non-storage "Walkway"
+ * spanning both rows (should merge into one plan area), column C storage.
+ */
+function makeCells(): GridCell[] {
+  const cells: GridCell[] = [];
+  for (let row = 0; row < 2; row += 1) {
+    // A: storage
+    cells.push({
+      id: `A-${row}`, column: 0, row, code: `A-0${row + 1}`, storage: true, purposeId: 'stock',
+      purposeName: 'Finished Goods', purposeColor: '#22c55e', enabled: true,
+    });
+    // B: non-storage walkway (merges vertically)
+    cells.push({
+      id: `B-${row}`, column: 1, row, code: '', storage: false, purposeId: 'walk',
+      purposeName: 'Walkway', purposeColor: '#64748b', enabled: true,
+    });
+    // C: storage
+    cells.push({
+      id: `C-${row}`, column: 2, row, code: `B-0${row + 1}`, storage: true, purposeId: 'stock',
+      purposeName: 'Finished Goods', purposeColor: '#22c55e', enabled: true,
+    });
+  }
+  return cells;
+}
+
+describe('WarehouseGrid — plan-area merge + interactions', () => {
+  it('shows storage codes and labels each merged non-storage region once', () => {
+    render(
+      <WarehouseGrid columns={3} rows={2} naming={DEFAULT_NAMING_SCHEME} cells={makeCells()} selectable />,
+    );
+    // Storage cells show their code.
+    expect(screen.getByText('A-01')).toBeInTheDocument();
+    expect(screen.getByText('A-02')).toBeInTheDocument();
+    // The two walkway cells merge: the purpose name appears exactly once (top-left).
+    expect(screen.getAllByText('Walkway')).toHaveLength(1);
+  });
+
+  it('fires onCellClick for a storage cell', () => {
+    const onCellClick = vi.fn();
+    render(
+      <WarehouseGrid columns={3} rows={2} naming={DEFAULT_NAMING_SCHEME} cells={makeCells()} selectable onCellClick={onCellClick} />,
+    );
+    fireEvent.click(screen.getByText('A-01'));
+    expect(onCellClick).toHaveBeenCalledTimes(1);
+    expect(onCellClick.mock.calls[0]?.[0]).toMatchObject({ id: 'A-0', code: 'A-01' });
+  });
+
+  it('fires onCellClick for a merged non-storage region cell (still selectable)', () => {
+    const onCellClick = vi.fn();
+    render(
+      <WarehouseGrid columns={3} rows={2} naming={DEFAULT_NAMING_SCHEME} cells={makeCells()} selectable onCellClick={onCellClick} />,
+    );
+    fireEvent.click(screen.getByText('Walkway'));
+    expect(onCellClick).toHaveBeenCalledTimes(1);
+    expect(onCellClick.mock.calls[0]?.[0]).toMatchObject({ storage: false, purposeName: 'Walkway' });
+  });
+
+  it('selects a whole column via its header (no areas)', () => {
+    const onHeaderClick = vi.fn();
+    render(
+      <WarehouseGrid columns={3} rows={2} naming={DEFAULT_NAMING_SCHEME} cells={makeCells()} selectable onHeaderClick={onHeaderClick} />,
+    );
+    // Column header 'A' is a clickable button when no areas are defined.
+    fireEvent.click(screen.getByRole('button', { name: 'A' }));
+    expect(onHeaderClick).toHaveBeenCalledWith('column', 0);
+  });
+});

--- a/src/modules/wms/components/WarehouseGrid.tsx
+++ b/src/modules/wms/components/WarehouseGrid.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/shared/utils';
 
 import { axisLabel } from '../services/layout';
 import type { LocationStatus, WarehouseNamingScheme } from '../types';
+import { regionRadius, regionShapeAt } from './planRegion';
 
 export interface GridCell {
   id: string;
@@ -27,6 +28,12 @@ export interface GridCell {
   code: string;
   /** Purpose colour — the single fill tint for a cell. */
   purposeColor?: string | null;
+  /** Whether the cell holds stock. Non-storage cells merge into a plan area. */
+  storage?: boolean;
+  /** Purpose id — the merge key: adjacent non-storage cells with the same id join. */
+  purposeId?: string | null;
+  /** Purpose name — labelled once at each merged region's top-left. */
+  purposeName?: string | null;
   /** Area colour, drawn as an outline (not a fill) on the region's edges. */
   areaColor?: string | null;
   /** Which sides of this cell sit on its area's boundary (for the outline). */
@@ -134,7 +141,9 @@ export function WarehouseGrid({
 
   return (
     <div className="overflow-auto rounded-md border bg-muted/20 p-3">
-      <div className="grid gap-1" style={{ gridTemplateColumns }}>
+      {/* gap-0 so non-storage plan areas can merge seamlessly; boxes re-create
+          their spacing with a small margin instead. */}
+      <div className="grid gap-0" style={{ gridTemplateColumns }}>
         {/* Header row: empty corner + column labels (only when headers match) */}
         {headersShown && (
           <>
@@ -146,7 +155,7 @@ export function WarehouseGrid({
                 disabled={!onHeaderClick}
                 onClick={() => onHeaderClick?.('column', c)}
                 className={cn(
-                  'px-1 text-center text-xs font-semibold text-muted-foreground',
+                  'mx-0.5 px-1 text-center text-xs font-semibold text-muted-foreground',
                   onHeaderClick && 'cursor-pointer rounded hover:bg-muted hover:text-foreground',
                 )}
               >
@@ -203,6 +212,13 @@ function Row({
   onCellDoubleClick?: (cell: GridCell) => void;
   onHeaderClick?: (axis: 'column' | 'row', index: number) => void;
 }) {
+  // Merge key for a cell: its purpose id when non-storage (so adjacent cells of
+  // the same purpose join into one plan area), else null (stands alone).
+  const mergeKeyAt = (column: number, r: number): string | null => {
+    const cc = cellByPos.get(`${column}:${r}`);
+    if (!cc || cc.outside || cc.storage !== false) return null;
+    return cc.purposeId ?? '__nostock__';
+  };
   return (
     <>
       {showHeader && (
@@ -211,7 +227,7 @@ function Row({
           disabled={!onHeaderClick}
           onClick={() => onHeaderClick?.('row', row)}
           className={cn(
-            'flex items-center pr-1 text-xs font-semibold text-muted-foreground',
+            'my-0.5 flex items-center pr-1 text-xs font-semibold text-muted-foreground',
             onHeaderClick && 'cursor-pointer rounded hover:bg-muted hover:text-foreground',
           )}
         >
@@ -221,9 +237,62 @@ function Row({
       {Array.from({ length: columns }, (_, c) => {
         const cell = cellByPos.get(`${c}:${row}`);
         if (!cell) {
-          return <div key={`empty-${c}-${row}`} className="h-10 rounded-sm border border-dashed border-border/50" />;
+          return <div key={`empty-${c}-${row}`} className="m-0.5 h-10 rounded-sm border border-dashed border-border/50" />;
         }
         const selected = selectedIds?.has(cell.id) ?? false;
+
+        // Non-storage cells render edge-to-edge; contiguous same-purpose cells
+        // merge into one solid, named plan area (paths, gates, cabins…).
+        if (!cell.outside && cell.storage === false) {
+          const shape = regionShapeAt(mergeKeyAt, c, row);
+          const color = cell.purposeColor ?? '#94a3b8';
+          const regionStyle: CSSProperties = {
+            backgroundColor: color,
+            borderRadius: regionRadius(shape.edges),
+          };
+          if (!selected) {
+            // A soft inset outline only on the region's outer edges keeps the
+            // interior seamless; a faint inner highlight adds a crisp lift.
+            const line = 'rgba(15,23,42,0.22)';
+            const shadows: string[] = ['inset 0 1px 0 0 rgba(255,255,255,0.18)'];
+            if (shape.edges.top) shadows.push(`inset 0 1.5px 0 0 ${line}`);
+            if (shape.edges.bottom) shadows.push(`inset 0 -1.5px 0 0 ${line}`);
+            if (shape.edges.left) shadows.push(`inset 1.5px 0 0 0 ${line}`);
+            if (shape.edges.right) shadows.push(`inset -1.5px 0 0 0 ${line}`);
+            regionStyle.boxShadow = shadows.join(', ');
+          }
+          return (
+            <button
+              key={cell.id}
+              type="button"
+              title={cell.purposeName ?? 'Non-storage area'}
+              disabled={!selectable}
+              onClick={(event) => onCellClick?.(cell, event.shiftKey)}
+              onDoubleClick={() => onCellDoubleClick?.(cell)}
+              style={regionStyle}
+              className={cn(
+                'relative flex h-10 items-center justify-center overflow-visible px-0.5 transition',
+                selectable && 'cursor-pointer hover:brightness-[1.06]',
+                selected && 'z-10 ring-2 ring-primary ring-offset-1',
+                cell.enabled === false && 'opacity-60',
+              )}
+            >
+              {shape.labelHere && cell.purposeName ? (
+                <span
+                  className={cn(
+                    'pointer-events-none absolute left-1 top-1/2 z-20 -translate-y-1/2 rounded bg-black/25 px-1.5 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide text-white shadow-sm',
+                    // A wide (horizontal) region lets its label run across it; a
+                    // narrow one keeps the label clipped so it can't spill over.
+                    shape.edges.right ? 'max-w-[calc(100%-0.5rem)] truncate' : 'whitespace-nowrap',
+                  )}
+                >
+                  {cell.purposeName}
+                </span>
+              ) : null}
+            </button>
+          );
+        }
+
         const disabled = cell.enabled === false || cell.status === 'BLOCKED' || cell.status === 'DAMAGED';
         const originName = originLabelById.get(cell.id);
         const fill = cell.outside ? null : cell.purposeColor;
@@ -260,7 +329,7 @@ function Row({
             onDoubleClick={() => onCellDoubleClick?.(cell)}
             style={Object.keys(style).length ? style : undefined}
             className={cn(
-              'relative flex h-10 items-center justify-center overflow-hidden rounded-sm border bg-background px-0.5 text-[10px] font-medium leading-none transition',
+              'relative m-0.5 flex h-10 items-center justify-center overflow-hidden rounded-md border bg-background px-0.5 text-[10px] font-medium leading-none shadow-sm transition',
               selectable && 'cursor-pointer hover:ring-1 hover:ring-ring',
               selected && 'ring-2 ring-primary ring-offset-1',
               disabled && 'bg-muted text-muted-foreground line-through opacity-60',

--- a/src/modules/wms/components/WarehouseMapGrid.tsx
+++ b/src/modules/wms/components/WarehouseMapGrid.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/shared/utils';
 
 import { axisLabel } from '../services/layout';
 import type { WarehouseNamingScheme } from '../types';
+import { regionRadius, regionShapeAt } from './planRegion';
 
 export interface MapCell {
   id: string;
@@ -22,6 +23,12 @@ export interface MapCell {
   color: string;
   hatch?: boolean;
   occupancyPct: number;
+  /** Whether the cell holds stock. Non-storage cells merge into a plan area. */
+  storage?: boolean;
+  /** Purpose id — merge key for joining adjacent non-storage cells. */
+  purposeId?: string | null;
+  /** Purpose name — labelled once at each merged region's top-left. */
+  purposeName?: string | null;
   highlighted?: boolean;
   dimmed?: boolean;
   tooltip?: string;
@@ -112,16 +119,26 @@ export function WarehouseMapGrid({
     ? `repeat(${columns}, minmax(3rem, 1fr))`
     : `auto repeat(${columns}, minmax(3rem, 1fr))`;
 
+  // Merge key for a cell: its purpose id when non-storage (so adjacent cells of
+  // the same purpose join into one plan area), else null (stands alone).
+  const mergeKeyAt = (column: number, r: number): string | null => {
+    const cc = cellByPos.get(`${column}:${r}`);
+    if (!cc || cc.storage !== false) return null;
+    return cc.purposeId ?? '__nostock__';
+  };
+
   return (
     <div className="overflow-auto rounded-md border bg-muted/20 p-3">
-      <div className="grid gap-1" style={{ gridTemplateColumns }}>
+      {/* gap-0 so non-storage plan areas merge seamlessly; boxes re-create their
+          spacing with a small margin instead. */}
+      <div className="grid gap-0" style={{ gridTemplateColumns }}>
         {!hasAreas && (
           <>
             <div />
             {columnLabels.map((label, c) => (
               <div
                 key={`col-${c}`}
-                className="px-1 text-center text-xs font-semibold text-muted-foreground"
+                className="mx-0.5 px-1 text-center text-xs font-semibold text-muted-foreground"
               >
                 {label}
               </div>
@@ -132,7 +149,7 @@ export function WarehouseMapGrid({
         {rowLabels.map((rowLabel, r) => (
           <div key={`row-${r}`} className="contents">
             {!hasAreas && (
-              <div className="flex items-center pr-1 text-xs font-semibold text-muted-foreground">
+              <div className="my-0.5 flex items-center pr-1 text-xs font-semibold text-muted-foreground">
                 {rowLabel}
               </div>
             )}
@@ -140,9 +157,55 @@ export function WarehouseMapGrid({
               const cell = cellByPos.get(`${c}:${r}`);
               if (!cell) {
                 return (
-                  <div key={`empty-${c}-${r}`} className="h-12 rounded-sm border border-dashed border-border/40" />
+                  <div key={`empty-${c}-${r}`} className="m-0.5 h-12 rounded-sm border border-dashed border-border/40" />
                 );
               }
+
+              // Non-storage cells render edge-to-edge; contiguous same-purpose
+              // cells merge into one solid, named plan area.
+              if (cell.storage === false) {
+                const shape = regionShapeAt(mergeKeyAt, c, r);
+                // A soft inset outline only on the region's outer edges keeps the
+                // interior seamless; a faint inner highlight adds a crisp lift.
+                const line = 'rgba(15,23,42,0.24)';
+                const shadows: string[] = ['inset 0 1px 0 0 rgba(255,255,255,0.18)'];
+                if (shape.edges.top) shadows.push(`inset 0 1.5px 0 0 ${line}`);
+                if (shape.edges.bottom) shadows.push(`inset 0 -1.5px 0 0 ${line}`);
+                if (shape.edges.left) shadows.push(`inset 1.5px 0 0 0 ${line}`);
+                if (shape.edges.right) shadows.push(`inset -1.5px 0 0 0 ${line}`);
+                return (
+                  <button
+                    key={cell.id}
+                    type="button"
+                    title={cell.tooltip ?? cell.purposeName ?? 'Non-storage area'}
+                    onClick={() => onCellClick?.(cell.id)}
+                    style={{
+                      backgroundColor: cell.color,
+                      backgroundImage: cell.hatch ? HATCH : undefined,
+                      borderRadius: regionRadius(shape.edges),
+                      boxShadow: shadows.join(', '),
+                    }}
+                    className={cn(
+                      'relative flex h-12 items-center justify-center overflow-visible px-0.5 transition',
+                      'hover:brightness-[1.06]',
+                      cell.dimmed && 'opacity-25',
+                    )}
+                  >
+                    {shape.labelHere && cell.purposeName ? (
+                      <span
+                        className={cn(
+                          'pointer-events-none absolute left-1 top-1/2 z-20 -translate-y-1/2 rounded bg-black/25 px-1.5 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide text-white shadow-sm',
+                          // Wide regions let the label run across; narrow ones clip it.
+                          shape.edges.right ? 'max-w-[calc(100%-0.5rem)] truncate' : 'whitespace-nowrap',
+                        )}
+                      >
+                        {cell.purposeName}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              }
+
               const fill = Math.max(0, Math.min(100, cell.occupancyPct));
               return (
                 <button
@@ -155,7 +218,7 @@ export function WarehouseMapGrid({
                     backgroundImage: cell.hatch ? HATCH : undefined,
                   }}
                   className={cn(
-                    'relative flex h-12 flex-col items-center justify-center overflow-hidden rounded-sm border border-black/10 px-0.5 text-[10px] font-semibold leading-none text-white/95 transition',
+                    'relative m-0.5 flex h-12 flex-col items-center justify-center overflow-hidden rounded-md border border-black/10 px-0.5 text-[10px] font-semibold leading-none text-white/95 shadow-sm transition',
                     'hover:ring-2 hover:ring-foreground/40',
                     cell.highlighted && 'ring-2 ring-foreground ring-offset-1',
                     cell.suggested && 'ring-2 ring-emerald-500 ring-offset-1',

--- a/src/modules/wms/components/planRegion.ts
+++ b/src/modules/wms/components/planRegion.ts
@@ -1,0 +1,58 @@
+/**
+ * Plan-area geometry for non-storage cells (paths, gates, cabins…).
+ *
+ * Non-storage cells render edge-to-edge with no gaps so that contiguous cells of
+ * the same purpose read as one solid "plan area" on the warehouse editor and the
+ * map. This helper answers, for a single cell, two rendering questions from its
+ * neighbours: which sides sit on the region's boundary (so we can outline it),
+ * and whether this cell is the region's top-left (so we label it exactly once).
+ *
+ * `mergeKeyAt` returns a stable key for a cell that should merge (a non-storage
+ * purpose id) or `null` for a cell that stands alone (storage, empty, outside).
+ * Same non-null key on an orthogonally-adjacent cell means "same region".
+ */
+export interface RegionEdges {
+  top: boolean;
+  right: boolean;
+  bottom: boolean;
+  left: boolean;
+}
+
+export interface RegionShape {
+  /** True on the top-left cell of a region — the one place we draw its label. */
+  labelHere: boolean;
+  /** Sides that sit on the region's outer boundary (for the outline). */
+  edges: RegionEdges;
+}
+
+export function regionShapeAt(
+  mergeKeyAt: (column: number, row: number) => string | null,
+  column: number,
+  row: number,
+): RegionShape {
+  const key = mergeKeyAt(column, row);
+  const same = (c: number, r: number) => key !== null && mergeKeyAt(c, r) === key;
+  return {
+    labelHere: key !== null && !same(column - 1, row) && !same(column, row - 1),
+    edges: {
+      top: !same(column, row - 1),
+      bottom: !same(column, row + 1),
+      left: !same(column - 1, row),
+      right: !same(column + 1, row),
+    },
+  };
+}
+
+/**
+ * CSS `border-radius` for a region cell: round only the *convex outer* corners
+ * (both meeting sides are on the boundary), so a merged area gets smooth rounded
+ * corners while its interior edges stay flush. Concave corners (L-shapes) stay
+ * square, which reads correctly.
+ */
+export function regionRadius(edges: RegionEdges, radius = 7): string {
+  const tl = edges.top && edges.left ? radius : 0;
+  const tr = edges.top && edges.right ? radius : 0;
+  const br = edges.bottom && edges.right ? radius : 0;
+  const bl = edges.bottom && edges.left ? radius : 0;
+  return `${tl}px ${tr}px ${br}px ${bl}px`;
+}

--- a/src/modules/wms/pages/WmsLabelsPage.tsx
+++ b/src/modules/wms/pages/WmsLabelsPage.tsx
@@ -8,10 +8,11 @@
  * thermal printer and stock.
  */
 import { Printer } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useReactToPrint } from 'react-to-print';
 
 import { LABEL_PRINT_PAGE_STYLE } from '@/modules/barcode/components/labelPrint';
+import { PaginationControls } from '@/shared/components/PaginationControls';
 import { Button, Card, CardContent, NativeSelect } from '@/shared/components/ui';
 
 import { WmsDisabledNotice } from '../components/WmsDisabledNotice';
@@ -28,14 +29,35 @@ export default function WmsLabelsPage() {
 
   const [warehouseId, setWarehouseId] = useState('');
   const [labelSet, setLabelSet] = useState<LabelSet>('locations');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  // The full print sheet (every QR) is heavy, so we only mount it while a print
+  // is in flight — keeping the initial page load cheap even for big warehouses.
+  const [printing, setPrinting] = useState(false);
 
   const printRef = useRef<HTMLDivElement>(null);
+  const printTriggered = useRef(false);
   const handlePrint = useReactToPrint({
     contentRef: printRef,
     documentTitle: 'WMS Labels 100x40mm',
     ignoreGlobalStyles: true,
     pageStyle: LABEL_PRINT_PAGE_STYLE,
+    onAfterPrint: () => setPrinting(false),
+    onPrintError: () => setPrinting(false),
   });
+
+  // Once the deferred print sheet has mounted, fire the browser print dialog —
+  // exactly once per print cycle (handlePrint's identity can change on render).
+  useEffect(() => {
+    if (!printing) {
+      printTriggered.current = false;
+      return;
+    }
+    if (printRef.current && !printTriggered.current) {
+      printTriggered.current = true;
+      handlePrint();
+    }
+  }, [printing, handlePrint]);
 
   const activeWarehouseId = warehouseId || warehouses[0]?.id || '';
   const warehouseLocations = useMemo(
@@ -63,6 +85,15 @@ export default function WmsLabelsPage() {
     }));
   }, [labelSet, warehouseLocations, activePallets]);
 
+  const total = labels.length;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  // Clamp the page if the label set / warehouse shrank the list under it.
+  const safePage = Math.min(page, totalPages);
+  const pagedLabels = useMemo(
+    () => labels.slice((safePage - 1) * pageSize, safePage * pageSize),
+    [labels, safePage, pageSize],
+  );
+
   if (!enabled) {
     return (
       <div className="mx-auto max-w-3xl p-4 md:p-6">
@@ -82,7 +113,14 @@ export default function WmsLabelsPage() {
         </div>
         <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
           {warehouses.length > 1 && labelSet === 'locations' ? (
-            <NativeSelect className="w-full sm:w-44" value={activeWarehouseId} onChange={(event) => setWarehouseId(event.target.value)}>
+            <NativeSelect
+              className="w-full sm:w-44"
+              value={activeWarehouseId}
+              onChange={(event) => {
+                setWarehouseId(event.target.value);
+                setPage(1);
+              }}
+            >
               {warehouses.map((wh) => (
                 <option key={wh.id} value={wh.id}>
                   {wh.name}
@@ -90,12 +128,23 @@ export default function WmsLabelsPage() {
               ))}
             </NativeSelect>
           ) : null}
-          <NativeSelect className="w-full sm:w-40" value={labelSet} onChange={(event) => setLabelSet(event.target.value as LabelSet)}>
+          <NativeSelect
+            className="w-full sm:w-40"
+            value={labelSet}
+            onChange={(event) => {
+              setLabelSet(event.target.value as LabelSet);
+              setPage(1);
+            }}
+          >
             <option value="locations">Location labels</option>
             <option value="pallets">Pallet labels</option>
           </NativeSelect>
-          <Button className="w-full sm:w-auto" onClick={() => handlePrint()} disabled={labels.length === 0}>
-            <Printer className="mr-2 h-4 w-4" /> Print
+          <Button
+            className="w-full sm:w-auto"
+            onClick={() => setPrinting(true)}
+            disabled={labels.length === 0 || printing}
+          >
+            <Printer className="mr-2 h-4 w-4" /> {printing ? 'Preparing…' : 'Print'}
           </Button>
         </div>
       </div>
@@ -107,29 +156,48 @@ export default function WmsLabelsPage() {
           </CardContent>
         </Card>
       ) : (
-        // Horizontal-scroll strip on phones (labels are a fixed 100mm wide), a
-        // wrapping grid from sm up. Keeps the page from overflowing sideways.
-        <div className="-mx-4 flex gap-4 overflow-x-auto px-4 pb-2 sm:mx-0 sm:flex-wrap sm:overflow-visible sm:px-0 sm:pb-0">
-          {labels.map((label) => (
-            <div
-              key={label.key}
-              className="shrink-0 overflow-hidden rounded-md border shadow-sm"
-              style={{ width: '100mm', height: '40mm' }}
-            >
-              <WmsPrintLabel data={label} />
-            </div>
-          ))}
-        </div>
+        <Card className="overflow-hidden">
+          {/* Horizontal-scroll strip on phones (labels are a fixed 100mm wide), a
+              wrapping grid from sm up. Keeps the page from overflowing sideways.
+              Only the current page of labels is rendered, so the QR count stays
+              small no matter how many locations/pallets exist. */}
+          <div className="-mx-4 flex gap-4 overflow-x-auto px-4 py-4 sm:mx-0 sm:flex-wrap sm:overflow-visible sm:px-4">
+            {pagedLabels.map((label) => (
+              <div
+                key={label.key}
+                className="shrink-0 overflow-hidden rounded-md border shadow-sm"
+                style={{ width: '100mm', height: '40mm' }}
+              >
+                <WmsPrintLabel data={label} />
+              </div>
+            ))}
+          </div>
+          <PaginationControls
+            page={safePage}
+            pageSize={pageSize}
+            total={total}
+            totalPages={totalPages}
+            onPageChange={setPage}
+            onPageSizeChange={(size) => {
+              setPageSize(size);
+              setPage(1);
+            }}
+          />
+        </Card>
       )}
 
-      {/* Hidden 100x40mm print sheet — one page per label for the TSC DA310. */}
-      <div aria-hidden style={{ position: 'fixed', left: '-10000px', top: 0 }}>
-        <div ref={printRef} className="barcode-print-sheet">
-          {labels.map((label) => (
-            <WmsPrintLabel key={label.key} data={label} />
-          ))}
+      {/* Hidden 100x40mm print sheet — one page per label for the TSC DA310.
+          Mounted only while printing so the full set of QRs never renders on a
+          normal page load. Print prints EVERY label, not just the current page. */}
+      {printing ? (
+        <div aria-hidden style={{ position: 'fixed', left: '-10000px', top: 0 }}>
+          <div ref={printRef} className="barcode-print-sheet">
+            {labels.map((label) => (
+              <WmsPrintLabel key={label.key} data={label} />
+            ))}
+          </div>
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }

--- a/src/modules/wms/pages/WmsMapPage.tsx
+++ b/src/modules/wms/pages/WmsMapPage.tsx
@@ -244,12 +244,20 @@ export default function WmsMapPage() {
         const purpose = location.purposeId ? purposeById.get(location.purposeId) : undefined;
         const isOutsideCell = outsideIds.has(location.id);
         const { color, hatch } = colorFor(location, purpose);
+        // Non-storage cells (paths, gates, cabins…) merge into a named plan area.
+        const isStorage = purpose ? purpose.holdsStock : true;
+        const region = {
+          storage: isStorage,
+          purposeId: location.purposeId,
+          purposeName: purpose?.name ?? null,
+        };
 
         if (moveSession) {
           // In move mode the highlight channels show destination validity.
           const isCurrent = location.id === moveSession.currentLocationId;
           const isValid = validDestinationIds.has(location.id);
           return {
+            ...region,
             id: location.id,
             column: location.column,
             row: location.row,
@@ -285,6 +293,7 @@ export default function WmsMapPage() {
         const passesFilter = matchesFilters(location);
         const isMatch = matchedIds.has(location.id);
         return {
+          ...region,
           id: location.id,
           column: location.column,
           row: location.row,

--- a/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
+++ b/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
@@ -108,6 +108,9 @@ export default function WmsWarehouseEditorPage() {
     return levelLocations.map((location) => {
       const area = showFullGrid ? null : findArea(areas, location.column, location.row);
       const key = area ? area.groupId ?? area.id : null;
+      const purpose = location.purposeId ? purposeById.get(location.purposeId) : undefined;
+      // No purpose (or a missing one) is treated as storage, like everywhere else.
+      const storage = purpose ? purpose.holdsStock : true;
       return {
         id: location.id,
         column: location.column,
@@ -116,7 +119,11 @@ export default function WmsWarehouseEditorPage() {
         // both the areas view and the full grid — toggling never renumbers a cell.
         code: location.code,
         // Purpose is the single colour axis for a cell.
-        purposeColor: location.purposeId ? purposeById.get(location.purposeId)?.color ?? null : null,
+        purposeColor: purpose?.color ?? null,
+        // Non-storage cells merge into a named plan area (paths, gates, cabins…).
+        storage,
+        purposeId: location.purposeId,
+        purposeName: purpose?.name ?? null,
         // Area is shown as an outline around its region, not a fill.
         areaColor: area?.color ?? null,
         areaEdges: area


### PR DESCRIPTION
Two WMS improvements.

## 1. Non-storage locations → named plan areas (editor + map)
Storage vs non-storage now read clearly on both the warehouse editor grid and the map. Storage cells stay as individual coded boxes; contiguous non-storage cells of the same purpose (paths, gates, cabins…) **merge into one solid, rounded, named plan area** in the purpose colour — a floor-plan look. Non-storage cells stay individually clickable in the editor so a mis-assigned cell can still be fixed.

- New `planRegion` helper (merge geometry, single-label placement, region edges, rounded convex corners).
- `WarehouseGrid` + `WarehouseMapGrid`: `gap-0` so regions merge seamlessly (boxes keep spacing via margins), soft outline + inner highlight, label chips that run across wide regions but clip on narrow ones (no collisions). Crisper storage boxes (rounded-md + shadow).
- Map keeps occupancy colours + bars for storage cells.
- New `WarehouseGrid` DOM test covering merge + click/selection.

## 2. Labels page pagination
The Labels page rendered every QR label at once (preview + hidden print sheet), so big warehouses hung on load. Preview is now paginated (25/50/100) and the full print sheet mounts only while printing. Print still prints every label.

## Verification
- Drove both grids and the labels list in a real browser (screenshots reviewed).
- WMS suite: **138 tests pass**. `npm run build` succeeds. Lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)