### PR TITLE
fix(wms): code every storage location, even outside an area

### DIFF
--- a/src/modules/wms/__tests__/wms.areas.test.ts
+++ b/src/modules/wms/__tests__/wms.areas.test.ts
@@ -111,7 +111,7 @@ describe('isOutside / outsideLocationIds', () => {
 });
 
 describe('rebuildWarehouseCodes', () => {
-  it('applies per-area codes and blanks cells outside every area', () => {
+  it('applies per-area codes and codes outside storage cells by grid position', () => {
     const area = makeWarehouseArea({
       name: 'M',
       color: '#000',
@@ -124,10 +124,12 @@ describe('rebuildWarehouseCodes', () => {
     const locations = [loc(0, 0), loc(1, 0), loc(2, 1)];
     const rebuilt = rebuildWarehouseCodes({ warehouse: w, zones: [], purposes: [], locations });
     const at = (c: number, r: number) => rebuilt.locations.find((l) => l.column === c && l.row === r)!;
-    expect(at(0, 0).code).toBe(''); // outside
     expect(at(1, 0).code).toBe('A-01'); // area origin
     expect(at(2, 1).code).toBe('B-02');
     expect(at(1, 0).barcode).toBe('A-01');
+    // The outside storage cell is still labelled (grid position, de-duped).
+    expect(at(0, 0).code).toBeTruthy();
+    expect(at(0, 0).code).not.toBe('A-01');
   });
 });
 
@@ -192,7 +194,7 @@ describe('buildAreaCodeMap — continuous numbering that skips disabled cells', 
     expect(at(4)).toBe('A-04');
   });
 
-  it('leaves cells outside every area uncoded', () => {
+  it('codes outside storage cells by grid position but leaves outside non-storage blank', () => {
     const area = makeWarehouseArea({
       name: 'Main',
       color: '#000',
@@ -201,11 +203,19 @@ describe('buildAreaCodeMap — continuous numbering that skips disabled cells', 
       endColumn: 2,
       endRow: 2,
     });
+    const aisle = makeCellPurpose('wh', { name: 'Aisle', color: '#000', holdsStock: false });
     const inside = loc(1, 1);
-    const outside = loc(0, 0);
-    const map = buildAreaCodeMap(wh({ areas: [area] }), [inside, outside]);
-    expect(map.get(inside.id)).toBe('A-01');
-    expect(map.get(outside.id)).toBeNull();
+    const outsideStorage = loc(4, 4); // storage, outside every area
+    const outsideAisle = { ...loc(0, 0), purposeId: aisle.id }; // non-storage, outside
+    const purposesById = new Map([[aisle.id, aisle]]);
+    const map = buildAreaCodeMap(
+      wh({ columns: 5, rows: 5, areas: [area] }),
+      [inside, outsideStorage, outsideAisle],
+      purposesById,
+    );
+    expect(map.get(inside.id)).toBe('A-01'); // area-relative
+    expect(map.get(outsideStorage.id)).toBe('E-05'); // whole-grid position
+    expect(map.get(outsideAisle.id)).toBeNull(); // non-storage → still blank
   });
 
   it('names only stock-holding cells, staying gapless across a non-storage cell', () => {

--- a/src/modules/wms/pages/WmsMapPage.tsx
+++ b/src/modules/wms/pages/WmsMapPage.tsx
@@ -242,7 +242,9 @@ export default function WmsMapPage() {
       levelLocations.map((location) => {
         const occ = occupancy.get(location.id);
         const purpose = location.purposeId ? purposeById.get(location.purposeId) : undefined;
-        const isOutsideCell = outsideIds.has(location.id);
+        // A cell with a code is a real, labelled location — never treated as
+        // "outside" (out-of-area storage cells now get a grid-position code).
+        const isOutsideCell = outsideIds.has(location.id) && !location.code;
         const { color, hatch } = colorFor(location, purpose);
         // Non-storage cells (paths, gates, cabins…) merge into a named plan area.
         const isStorage = purpose ? purpose.holdsStock : true;

--- a/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
+++ b/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
@@ -9,7 +9,7 @@
  * Every edit persists immediately and is undoable.
  */
 import { ArrowLeft, Download, Loader2, Map as MapIcon, Redo2, Save, Undo2 } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -41,6 +41,7 @@ import {
   buildLocationsCsv,
   buildTemplate,
   findArea,
+  locationHoldsStock,
   makeWarehouseArea,
   outsideLocationIds,
   rebuildWarehouseCodes,
@@ -61,7 +62,7 @@ export default function WmsWarehouseEditorPage() {
   const { bundle, loading, busy, canUndo, canRedo, mutate, undo, redo } = editor;
 
   const warehouse = bundle?.warehouse ?? null;
-  const purposes = bundle?.purposes ?? [];
+  const purposes = useMemo(() => bundle?.purposes ?? [], [bundle]);
   const areas = useMemo(() => bundle?.warehouse.areas ?? [], [bundle]);
   // One entry per logical area (blocks sharing a groupId), for "add to existing".
   const areaGroups = useMemo(() => {
@@ -93,6 +94,24 @@ export default function WmsWarehouseEditorPage() {
     [warehouse, locations],
   );
   const safeLevel = warehouse ? Math.min(level, Math.max(0, warehouse.levels - 1)) : 0;
+
+  // One-time self-heal: warehouses saved before storage cells were always
+  // numbered may have enabled storage locations left blank (e.g. storage that
+  // sits outside every area). Renumber once on open so every storage location
+  // shows its code. Guarded per warehouse so it runs at most once, and only when
+  // something is actually missing (so normal warehouses are untouched).
+  const healedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!bundle || !warehouse || busy) return;
+    if (healedRef.current === warehouse.id) return;
+    const byId = new Map(purposes.map((purpose) => [purpose.id, purpose]));
+    const missing = locations.some(
+      (location) => location.enabled !== false && locationHoldsStock(location, byId) && !location.code,
+    );
+    if (!missing) return;
+    healedRef.current = warehouse.id;
+    void mutate((current) => rebuildWarehouseCodes(current));
+  }, [bundle, warehouse, busy, purposes, locations, mutate]);
 
   const levelLocations = useMemo(
     () => locations.filter((location) => location.level === safeLevel),
@@ -134,7 +153,9 @@ export default function WmsWarehouseEditorPage() {
               right: areaKeyAt(location.column + 1, location.row) !== key,
             }
           : undefined,
-        outside: showFullGrid ? false : outsideIds.has(location.id),
+        // A cell with a code is a real, labelled location — never shown as
+        // "outside" (out-of-area storage cells now get a grid-position code).
+        outside: showFullGrid ? false : outsideIds.has(location.id) && !location.code,
         enabled: location.enabled,
         status: location.status,
       };

--- a/src/modules/wms/services/areas.ts
+++ b/src/modules/wms/services/areas.ts
@@ -151,12 +151,14 @@ export function buildAreaCodeMap(
   const naming = warehouse.namingScheme;
   const groupKey = (area: WarehouseArea) => area.groupId ?? area.id;
   // Assign each location to the first area that contains it, then group blocks
-  // that share a groupId so they number continuously as one area.
+  // that share a groupId so they number continuously as one area. Cells that
+  // fall in no area are collected separately (numbered by grid position below).
   const byGroup = new Map<string, { area: WarehouseArea; cells: WarehouseLocation[] }>();
+  const outsideCells: WarehouseLocation[] = [];
   for (const location of locations) {
     const area = areas.find((a) => areaContains(a, location.column, location.row));
     if (!area) {
-      result.set(location.id, null); // outside every area
+      outsideCells.push(location);
       continue;
     }
     const key = groupKey(area);
@@ -168,6 +170,20 @@ export function buildAreaCodeMap(
   // A cell is numbered only when it is enabled AND actually holds stock —
   // disabled cells and non-storage cells (paths, gates, cabins) carry no code.
   const isCoded = (l: WarehouseLocation) => l.enabled !== false && locationHoldsStock(l, purposesById);
+
+  // Keep every assigned code unique across the whole warehouse: area cells claim
+  // theirs first, then outside cells de-dupe around them.
+  const seen = new Set<string>();
+  const unique = (base: string): string => {
+    let code = base;
+    if (seen.has(code)) {
+      let suffix = 2;
+      while (seen.has(`${code}#${suffix}`)) suffix += 1;
+      code = `${code}#${suffix}`;
+    }
+    seen.add(code);
+    return code;
+  };
 
   for (const { area, cells } of byGroup.values()) {
     const coded = cells.filter(isCoded);
@@ -196,8 +212,29 @@ export function buildAreaCodeMap(
       if (warehouse.levels > 1) {
         segments.push(axisLabel(naming.levelStyle, cell.level, warehouse.levels));
       }
-      result.set(cell.id, segments.join(naming.separator || '-'));
+      result.set(cell.id, unique(segments.join(naming.separator || '-')));
     }
+  }
+
+  // Storage cells that fall outside every area still get a code — numbered by
+  // their whole-grid position — so no storage location is ever unlabelled.
+  // Non-storage or disabled outside cells stay blank.
+  for (const location of outsideCells) {
+    if (!isCoded(location)) {
+      result.set(location.id, null);
+      continue;
+    }
+    result.set(
+      location.id,
+      unique(
+        buildLocationCode(
+          { columns: warehouse.columns, rows: warehouse.rows, levels: warehouse.levels, naming },
+          location.column,
+          location.row,
+          location.level,
+        ),
+      ),
+    );
   }
 
   return result;


### PR DESCRIPTION
Storage cells that fell **outside every drawn area** were left blank (no code) — that's why some pink storage boxes showed no code while in-area (green) ones did.

## Fix
Every enabled storage cell now gets a code:
- **Inside an area** → area-relative code (unchanged).
- **Outside all areas** → numbered by whole-grid position, de-duped so it never collides with an area code.
- Non-storage / disabled cells still carry no code.

Also:
- Editor + map: a cell that has a code is a real location, no longer rendered as "outside" (dashed/blank) — it shows its code.
- Editor: a one-time self-heal on open renumbers any warehouse still holding blank storage cells, so **existing layouts show codes immediately** (no manual edit needed).

## Verification
- Rendered a warehouse with storage inside AND outside the area: **18/18 outside-area storage cells now coded** (`D-01…F-06`), shown as normal boxes.
- WMS suite: **138 tests pass** (updated the two tests that asserted the old "outside = blank" behavior). Build clean, lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)