### PR TITLE
feat(pwa): auto-detect new deploys and prompt to refresh

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,5 @@
 import { AuthInitializer } from '@/core/auth/components/AuthInitializer';
+import { AppVersionWatcher } from '@/core/pwa/AppVersionWatcher';
 import { PWAInstallPrompt } from '@/core/pwa/PWAInstallPrompt';
 import { ErrorBoundary } from '@/shared/components';
 
@@ -17,6 +18,7 @@ function App() {
           <AppRoutes />
         </AuthInitializer>
         <PWAInstallPrompt />
+        <AppVersionWatcher />
       </AppProviders>
     </ErrorBoundary>
   );

--- a/src/core/pwa/AppVersionWatcher.tsx
+++ b/src/core/pwa/AppVersionWatcher.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Detects when a newer build has been deployed and offers a one-tap refresh.
+ *
+ * Each build bakes in a unique `__BUILD_ID__` and writes the same id to
+ * `/version.json`. This component polls that file (bypassing the HTTP cache) and,
+ * when the server's id differs from the running bundle's, shows a single
+ * non-blocking "new version available" toast. There is **no service worker**
+ * here, so push-notification registration is untouched.
+ *
+ * The toast is shown at most once per new version per tab session, so it can
+ * never loop even if a reload is served a stale document.
+ */
+const CHECK_INTERVAL_MS = 60_000;
+
+async function fetchServerVersion(): Promise<string | null> {
+  try {
+    const response = await fetch(`/version.json?_=${Date.now()}`, { cache: 'no-store' });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { version?: string };
+    return typeof data.version === 'string' ? data.version : null;
+  } catch {
+    return null; // offline / not deployed (e.g. dev) — nothing to do
+  }
+}
+
+export function AppVersionWatcher() {
+  const promptedRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const check = async () => {
+      if (cancelled || promptedRef.current) return;
+      const serverVersion = await fetchServerVersion();
+      if (cancelled || !serverVersion || serverVersion === __BUILD_ID__) return;
+
+      // At most one prompt per new version per session.
+      const key = `app-update-prompt-${serverVersion}`;
+      if (sessionStorage.getItem(key)) return;
+      sessionStorage.setItem(key, '1');
+      promptedRef.current = true;
+
+      toast('A new version is available', {
+        description: 'Refresh to load the latest updates.',
+        duration: Infinity,
+        action: { label: 'Refresh', onClick: () => window.location.reload() },
+      });
+    };
+
+    void check();
+    const intervalId = window.setInterval(() => void check(), CHECK_INTERVAL_MS);
+    const onFocus = () => void check();
+    window.addEventListener('focus', onFocus);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+/** Unique id for the current build, injected by vite.config `define`. */
+declare const __BUILD_ID__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,9 +5,27 @@ import react from '@vitejs/plugin-react-swc'
 import path from 'path'
 import { VitePWA } from 'vite-plugin-pwa'
 
+// A unique id per build, baked into the bundle (__BUILD_ID__) and written to
+// /version.json. The app polls version.json to detect a newer deploy and offer
+// a refresh — no service worker involved, so push notifications are unaffected.
+const BUILD_ID = Date.now().toString()
+
 export default defineConfig({
+  define: {
+    __BUILD_ID__: JSON.stringify(BUILD_ID),
+  },
   plugins: [
     react(),
+    {
+      name: 'emit-version-json',
+      generateBundle() {
+        this.emitFile({
+          type: 'asset',
+          fileName: 'version.json',
+          source: JSON.stringify({ version: BUILD_ID }),
+        })
+      },
+    },
     VitePWA({
       registerType: 'autoUpdate',
       injectRegister: false,


### PR DESCRIPTION
## Why
Deploys weren't reaching users until they manually hard-refreshed — the root cause behind "I don't see the fix." The app has no update mechanism: the generated `sw.js` is never registered, and the Firebase worker doesn't cache assets.

## What
A lightweight version check with **no service-worker changes** (so push notifications can't break):
- `vite.config` bakes a unique `__BUILD_ID__` into the bundle and emits `/version.json` with the same id.
- `AppVersionWatcher` polls `/version.json` (cache-bypassing) on load, on window focus, and every 60s. When the deployed id differs from the running bundle, it shows a single non-blocking "A new version is available — Refresh" toast.
- Shows at most **once per version per tab session** (sessionStorage-guarded), so it can never loop.

## Verified
- `npm run build` emits `version.json` and the matching id is baked into the JS bundle.
- Typecheck + lint clean on new files. Full WMS suite unaffected (the 2 App.test failures are pre-existing — App.tsx never imported `Toaster`).

Note: users still need to reach a build that *contains* the watcher once (a single hard-refresh); after that, future deploys prompt automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)