### PR TITLE
fix(wms): outside-area cells show their config (codes + plan areas)

### DIFF
--- a/src/modules/wms/pages/WmsMapPage.tsx
+++ b/src/modules/wms/pages/WmsMapPage.tsx
@@ -242,9 +242,10 @@ export default function WmsMapPage() {
       levelLocations.map((location) => {
         const occ = occupancy.get(location.id);
         const purpose = location.purposeId ? purposeById.get(location.purposeId) : undefined;
-        // A cell with a code is a real, labelled location — never treated as
-        // "outside" (out-of-area storage cells now get a grid-position code).
-        const isOutsideCell = outsideIds.has(location.id) && !location.code;
+        // Only a truly unconfigured cell (no code AND no purpose) is treated as
+        // "outside". Any configured cell — a coded storage location or a purposed
+        // non-storage cell — shows its config even outside a drawn area.
+        const isOutsideCell = outsideIds.has(location.id) && !location.code && !location.purposeId;
         const { color, hatch } = colorFor(location, purpose);
         // Non-storage cells (paths, gates, cabins…) merge into a named plan area.
         const isStorage = purpose ? purpose.holdsStock : true;

--- a/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
+++ b/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
@@ -153,9 +153,12 @@ export default function WmsWarehouseEditorPage() {
               right: areaKeyAt(location.column + 1, location.row) !== key,
             }
           : undefined,
-        // A cell with a code is a real, labelled location — never shown as
-        // "outside" (out-of-area storage cells now get a grid-position code).
-        outside: showFullGrid ? false : outsideIds.has(location.id) && !location.code,
+        // Only a truly unconfigured cell (no code AND no purpose) is shown as
+        // "outside" (dashed ·). Any cell the user has configured — a coded
+        // storage location, or a purposed non-storage cell — shows its config
+        // even when it falls outside a drawn area.
+        outside:
+          showFullGrid ? false : outsideIds.has(location.id) && !location.code && !location.purposeId,
         enabled: location.enabled,
         status: location.status,
       };


### PR DESCRIPTION
In the areas view, cells outside every drawn area rendered blank (dashed `·`) even when configured — that's why the right-side cells looked empty.

Now only a **truly unconfigured** cell (no code AND no purpose) shows as outside. Any configured cell shows its config:
- coded storage location → shows its code,
- purposed non-storage cell → merges into its named plan area,

…whether or not it's inside a drawn area. Editor grid + map.

## Verified
- Rendered an area with an outside path + outside storage + no-purpose cells: the path merges into "WALKABLE PATH", outside storage shows codes (`E-01…H-06`) — no blank `·`.
- WMS suite 138 tests pass. Typecheck + lint clean. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)