### PR TITLE
feat(wms): custom colours for purposes and areas

### DIFF
--- a/src/modules/wms/components/PurposeDialog.tsx
+++ b/src/modules/wms/components/PurposeDialog.tsx
@@ -94,7 +94,7 @@ export function PurposeDialog({ open, onOpenChange, locationCount, onSubmit }: P
 
           <div className="space-y-1.5">
             <Label>Colour</Label>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               {PURPOSE_COLOR_PRESETS.map((preset) => (
                 <button
                   key={preset}
@@ -104,10 +104,24 @@ export function PurposeDialog({ open, onOpenChange, locationCount, onSubmit }: P
                   style={{ backgroundColor: preset }}
                   className={cn(
                     'h-7 w-7 rounded-full border-2 transition',
-                    color === preset ? 'border-foreground ring-2 ring-ring' : 'border-transparent',
+                    color.toLowerCase() === preset.toLowerCase()
+                      ? 'border-foreground ring-2 ring-ring'
+                      : 'border-transparent',
                   )}
                 />
               ))}
+              <label
+                className="flex h-7 items-center gap-1.5 rounded-full border px-2 text-xs text-muted-foreground"
+                title="Pick any colour"
+              >
+                <input
+                  type="color"
+                  value={color}
+                  onChange={(event) => setColor(event.target.value)}
+                  className="h-4 w-4 cursor-pointer border-0 bg-transparent p-0"
+                />
+                Custom
+              </label>
             </div>
           </div>
 

--- a/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
+++ b/src/modules/wms/pages/WmsWarehouseEditorPage.tsx
@@ -52,7 +52,8 @@ import {
   renameLocation,
 } from '../services';
 import { useWarehouseEditor, useWmsEnabled, useWmsRole, wmsStore } from '../store';
-import type { CellPurpose, WarehouseLocation } from '../types';
+import type { CellPurpose, WarehouseArea, WarehouseLocation } from '../types';
+import { nowIso } from '../utils';
 
 export default function WmsWarehouseEditorPage() {
   const { warehouseId = '' } = useParams();
@@ -267,6 +268,41 @@ export default function WmsWarehouseEditorPage() {
           }),
         ),
       'Area removed.',
+      true,
+    );
+  }
+
+  // -- colour customisation (recolour an existing purpose / area) -----------
+
+  function updatePurposeColor(purposeId: string, color: string) {
+    void run(
+      () =>
+        mutate((current) => ({
+          ...current,
+          purposes: current.purposes.map((purpose) =>
+            purpose.id === purposeId ? { ...purpose, color, updatedAt: nowIso() } : purpose,
+          ),
+        })),
+      undefined,
+      true,
+    );
+  }
+
+  function updateAreaColor(target: WarehouseArea, color: string) {
+    // Recolour every block of the logical area (blocks sharing a groupId).
+    const key = target.groupId ?? target.id;
+    void run(
+      () =>
+        mutate((current) => ({
+          ...current,
+          warehouse: {
+            ...current.warehouse,
+            areas: (current.warehouse.areas ?? []).map((area) =>
+              (area.groupId ?? area.id) === key ? { ...area, color } : area,
+            ),
+          },
+        })),
+      undefined,
       true,
     );
   }
@@ -504,7 +540,15 @@ export default function WmsWarehouseEditorPage() {
         <div className="flex flex-wrap items-center gap-2">
           {purposes.map((purpose) => (
             <Badge key={purpose.id} variant="outline" className="gap-1.5">
-              <span className="h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: purpose.color }} />
+              <input
+                type="color"
+                value={purpose.color}
+                disabled={busy}
+                onChange={(event) => updatePurposeColor(purpose.id, event.target.value)}
+                title={`Change ${purpose.name} colour`}
+                aria-label={`Change ${purpose.name} colour`}
+                className="h-3.5 w-3.5 shrink-0 cursor-pointer rounded-sm border-0 bg-transparent p-0"
+              />
               {purpose.name}
               <span className="text-[10px] text-muted-foreground">
                 · {purpose.holdsStock ? 'storage' : 'no stock'}
@@ -519,7 +563,15 @@ export default function WmsWarehouseEditorPage() {
         <div className="flex flex-wrap items-center gap-2">
           {areas.map((area) => (
             <Badge key={area.id} variant="outline" className="gap-1.5 pr-1">
-              <span className="h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: area.color }} />
+              <input
+                type="color"
+                value={area.color}
+                disabled={busy}
+                onChange={(event) => updateAreaColor(area, event.target.value)}
+                title={`Change ${area.name} colour`}
+                aria-label={`Change ${area.name} colour`}
+                className="h-3.5 w-3.5 shrink-0 cursor-pointer rounded-sm border-0 bg-transparent p-0"
+              />
               {area.name}
               {area.prefix ? (
                 <span className="font-mono text-[10px] text-muted-foreground">· {area.prefix}-</span>


### PR DESCRIPTION
Cell colours were limited to a fixed preset palette. Now users can pick **any** colour.

- **PurposeDialog**: adds a "Custom" colour picker (any hex) alongside the presets — matching the AreaDialog, which already had one.
- **Editor legends**: the purpose legend and area legend now show an inline colour swatch you can click to recolour an existing purpose/area on the spot. Recolouring an area updates every block of that logical area. Changes persist and are undoable.

## Verified
- Rendered the editable legends: each purpose/area shows a clickable swatch.
- Typecheck clean, 138 WMS tests pass, build clean. (One pre-existing lint error in PurposeDialog's reset-on-open effect is unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)