### PR TITLE
feat(wms): empty-location dropdown on put-away + fix empty detection

### DIFF
--- a/src/modules/wms/__tests__/wms.emptyLocations.test.ts
+++ b/src/modules/wms/__tests__/wms.emptyLocations.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOccupancyIndex,
+  countEmptyLocations,
+  groupEmptyLocationsBySection,
+  isEmptyDestination,
+  makeCellPurpose,
+  makeInventoryRecord,
+  makeWarehouseArea,
+  makeWarehouseLocation,
+} from '../services';
+import type { CellPurpose, Warehouse, WarehouseLocation } from '../types';
+
+const rack = makeCellPurpose('wh', { name: 'Racking', color: '#22c55e', holdsStock: true });
+const aisle = makeCellPurpose('wh', { name: 'Aisle', color: '#64748b', holdsStock: false });
+const purposesById = new Map<string, CellPurpose>([
+  [rack.id, rack],
+  [aisle.id, aisle],
+]);
+
+/** Area "Bulk" covers columns 0-1; column 2 sits outside every area. */
+const bulk = makeWarehouseArea({
+  name: 'Bulk',
+  color: '#000',
+  startColumn: 0,
+  startRow: 0,
+  endColumn: 1,
+  endRow: 1,
+});
+
+function wh(): Warehouse {
+  return {
+    id: 'wh',
+    code: 'WH',
+    name: 'Main',
+    description: '',
+    enabled: true,
+    columns: 3,
+    rows: 2,
+    levels: 1,
+    namingScheme: { columnStyle: 'LETTERS', rowStyle: 'NUMBERS', levelStyle: 'NUMBERS', prefix: '', separator: '-' },
+    areas: [bulk],
+    createdAt: 'x',
+    updatedAt: 'x',
+  };
+}
+
+function loc(code: string, column: number, row: number, overrides: Partial<WarehouseLocation> = {}) {
+  return {
+    ...makeWarehouseLocation('wh', { code, barcode: code, column, row, level: 0 }),
+    purposeId: rack.id,
+    ...overrides,
+  };
+}
+
+describe('isEmptyDestination', () => {
+  const empty = loc('A-01', 0, 0);
+  const occupancy = buildOccupancyIndex([empty], [], [], purposesById);
+
+  it('accepts an enabled, stock-holding, empty location', () => {
+    expect(isEmptyDestination(empty, occupancy, purposesById)).toBe(true);
+  });
+
+  it('rejects a disabled location', () => {
+    const off = { ...empty, enabled: false };
+    expect(isEmptyDestination(off, occupancy, purposesById)).toBe(false);
+  });
+
+  it('rejects a non-storage location (aisle)', () => {
+    const path = { ...empty, purposeId: aisle.id };
+    expect(isEmptyDestination(path, occupancy, purposesById)).toBe(false);
+  });
+
+  it('rejects a location that already holds stock', () => {
+    const full = loc('A-02', 0, 1);
+    const occ = buildOccupancyIndex(
+      [full],
+      [makeInventoryRecord({ locationId: full.id, itemCode: 'SKU1', quantity: 5 })],
+      [],
+      purposesById,
+    );
+    expect(isEmptyDestination(full, occ, purposesById)).toBe(false);
+  });
+});
+
+describe('groupEmptyLocationsBySection', () => {
+  it('groups empty locations by their area, and outside cells as "Unassigned"', () => {
+    const inArea1 = loc('A-01', 0, 0);
+    const inArea2 = loc('B-01', 1, 0);
+    const outside = loc('C-01', 2, 0);
+    const locations = [outside, inArea2, inArea1]; // deliberately unsorted
+    const occupancy = buildOccupancyIndex(locations, [], [], purposesById);
+
+    const sections = groupEmptyLocationsBySection({
+      locations,
+      warehouses: [wh()],
+      occupancy,
+      purposesById,
+    });
+
+    expect(sections.map((s) => s.label)).toEqual(['Bulk', 'Unassigned']);
+    expect(sections[0]!.locations.map((l) => l.code)).toEqual(['A-01', 'B-01']); // sorted
+    expect(sections[1]!.locations.map((l) => l.code)).toEqual(['C-01']);
+    expect(countEmptyLocations(sections)).toBe(3);
+  });
+
+  it('omits occupied, disabled, and non-storage locations', () => {
+    const empty = loc('A-01', 0, 0);
+    const occupied = loc('B-01', 1, 0);
+    const disabled = loc('A-02', 0, 1, { enabled: false });
+    const path = loc('B-02', 1, 1, { purposeId: aisle.id });
+    const locations = [empty, occupied, disabled, path];
+    const occupancy = buildOccupancyIndex(
+      locations,
+      [makeInventoryRecord({ locationId: occupied.id, itemCode: 'SKU1', quantity: 3 })],
+      [],
+      purposesById,
+    );
+
+    const sections = groupEmptyLocationsBySection({
+      locations,
+      warehouses: [wh()],
+      occupancy,
+      purposesById,
+    });
+
+    expect(countEmptyLocations(sections)).toBe(1);
+    expect(sections[0]!.locations[0]!.code).toBe('A-01');
+  });
+
+  it('excludes the source location (never offer a move onto itself)', () => {
+    const a = loc('A-01', 0, 0);
+    const b = loc('B-01', 1, 0);
+    const locations = [a, b];
+    const occupancy = buildOccupancyIndex(locations, [], [], purposesById);
+
+    const sections = groupEmptyLocationsBySection({
+      locations,
+      warehouses: [wh()],
+      occupancy,
+      purposesById,
+      excludeLocationId: a.id,
+    });
+
+    expect(countEmptyLocations(sections)).toBe(1);
+    expect(sections[0]!.locations[0]!.code).toBe('B-01');
+  });
+
+  it('sorts codes naturally (A-2 before A-10)', () => {
+    const locations = [loc('A-10', 0, 0), loc('A-2', 1, 0)];
+    const occupancy = buildOccupancyIndex(locations, [], [], purposesById);
+    const sections = groupEmptyLocationsBySection({
+      locations,
+      warehouses: [wh()],
+      occupancy,
+      purposesById,
+    });
+    expect(sections[0]!.locations.map((l) => l.code)).toEqual(['A-2', 'A-10']);
+  });
+});

--- a/src/modules/wms/pages/WmsReceivePage.tsx
+++ b/src/modules/wms/pages/WmsReceivePage.tsx
@@ -28,7 +28,15 @@ import type { WmsLabelData } from '../components/WmsPrintLabel';
 import { WmsPrintLabelButton } from '../components/WmsPrintLabelButton';
 import { WmsScanButton } from '../components/WmsScanButton';
 import type { MoveItem, PutawaySuggestion, ValidationResult } from '../services';
-import { locationHoldsStock, outsideLocationIds, suggestPutaway, validateMove } from '../services';
+import {
+  buildOccupancyIndex,
+  countEmptyLocations,
+  groupEmptyLocationsBySection,
+  locationHoldsStock,
+  outsideLocationIds,
+  suggestPutaway,
+  validateMove,
+} from '../services';
 import { useWarehouses, useWmsCollection, useWmsEnabled, useWmsSettings, wmsStore } from '../store';
 import type { MaterialWarehouseProfile } from '../types';
 import { notifyFail, notifyOk } from '../utils';
@@ -140,6 +148,25 @@ export default function WmsReceivePage() {
     () => new Set(availableSpaces.slice(0, 3).map((s) => s.location.id)),
     [availableSpaces],
   );
+
+  const occupancy = useMemo(
+    () => buildOccupancyIndex(warehouseLocations, inventory, pallets, purposeById),
+    [warehouseLocations, inventory, pallets, purposeById],
+  );
+
+  // Empty spaces only, grouped by section — the dropdown the operator picks from.
+  // Restricted to spaces the putaway engine already deemed legal for this item.
+  const emptyBySection = useMemo(() => {
+    const legalIds = new Set(availableSpaces.map((space) => space.location.id));
+    return groupEmptyLocationsBySection({
+      locations: warehouseLocations.filter((location) => legalIds.has(location.id)),
+      warehouses,
+      occupancy,
+      purposesById: purposeById,
+    });
+  }, [availableSpaces, warehouseLocations, warehouses, occupancy, purposeById]);
+
+  const totalEmpty = useMemo(() => countEmptyLocations(emptyBySection), [emptyBySection]);
 
   const SPACE_LIMIT = 90;
   const filteredSpaces = useMemo(() => {
@@ -422,6 +449,38 @@ export default function WmsReceivePage() {
             </p>
           ) : (
             <>
+              {/* Pick an empty space by section — no scanning needed. */}
+              <div className="space-y-1.5">
+                <Label htmlFor="empty-space-select">
+                  Pick an empty location
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">
+                    ({totalEmpty} empty)
+                  </span>
+                </Label>
+                <NativeSelect
+                  id="empty-space-select"
+                  value={destLocationId ?? ''}
+                  onChange={(event) => setDestLocationId(event.target.value || null)}
+                >
+                  <option value="">Select an empty location…</option>
+                  {emptyBySection.map((section) => (
+                    <optgroup key={section.key} label={section.label}>
+                      {section.locations.map((location) => (
+                        <option key={location.id} value={location.id}>
+                          {location.code}
+                          {recommendedIds.has(location.id) ? ' ★' : ''}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ))}
+                </NativeSelect>
+                {totalEmpty === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No empty locations for this item — the spaces below are partly filled.
+                  </p>
+                ) : null}
+              </div>
+
               <div className="flex gap-2">
                 <Input
                   value={spaceQuery}

--- a/src/modules/wms/pages/WmsTransferPage.tsx
+++ b/src/modules/wms/pages/WmsTransferPage.tsx
@@ -28,7 +28,13 @@ import {
 import { WmsDisabledNotice } from '../components/WmsDisabledNotice';
 import { WmsScanButton } from '../components/WmsScanButton';
 import type { MoveItem, ValidationResult } from '../services';
-import { buildOccupancyIndex, findArea, locationHoldsStock, validateMove } from '../services';
+import {
+  buildOccupancyIndex,
+  countEmptyLocations,
+  groupEmptyLocationsBySection,
+  locationHoldsStock,
+  validateMove,
+} from '../services';
 import { useWmsCollection, useWmsEnabled, useWmsSettings, wmsStore } from '../store';
 import type {
   InventoryRecord,
@@ -84,36 +90,20 @@ export default function WmsTransferPage() {
   );
 
   // Empty destination locations, grouped by section (their area) so the operator
-  // can pick where to place the item instead of scanning. Only enabled,
-  // stock-holding, currently-empty locations qualify; the source is excluded.
-  const emptyBySection = useMemo(() => {
-    const areasByWarehouse = new Map(warehouses.map((warehouse) => [warehouse.id, warehouse.areas ?? []]));
-    const groups = new Map<string, { label: string; locations: WarehouseLocation[] }>();
-    for (const location of locations) {
-      if (location.id === sourceLocationId) continue;
-      if (location.enabled === false) continue;
-      if (!locationHoldsStock(location, purposeById)) continue;
-      if ((occupancy.get(location.id)?.occupancyPct ?? 0) > 0) continue; // only empty
-      const areas = areasByWarehouse.get(location.warehouseId) ?? [];
-      const area = findArea(areas, location.column, location.row);
-      const key = area ? `${location.warehouseId}:${area.groupId ?? area.id}` : `${location.warehouseId}:none`;
-      const label = area?.name ?? 'Unassigned';
-      const group = groups.get(key) ?? { label, locations: [] };
-      group.locations.push(location);
-      groups.set(key, group);
-    }
-    const sections = [...groups.entries()].map(([key, group]) => ({
-      key,
-      label: group.label,
-      locations: group.locations.sort((a, b) => a.code.localeCompare(b.code, undefined, { numeric: true })),
-    }));
-    return sections.sort((a, b) => a.label.localeCompare(b.label));
-  }, [locations, warehouses, sourceLocationId, purposeById, occupancy]);
-
-  const totalEmpty = useMemo(
-    () => emptyBySection.reduce((sum, section) => sum + section.locations.length, 0),
-    [emptyBySection],
+  // can pick where to place the item instead of scanning. The source is excluded.
+  const emptyBySection = useMemo(
+    () =>
+      groupEmptyLocationsBySection({
+        locations,
+        warehouses,
+        occupancy,
+        purposesById: purposeById,
+        excludeLocationId: sourceLocationId,
+      }),
+    [locations, warehouses, occupancy, purposeById, sourceLocationId],
   );
+
+  const totalEmpty = useMemo(() => countEmptyLocations(emptyBySection), [emptyBySection]);
 
   const sourceLocation = sourceLocationId ? locations.find((l) => l.id === sourceLocationId) ?? null : null;
   const destLocation = destLocationId ? locations.find((l) => l.id === destLocationId) ?? null : null;

--- a/src/modules/wms/services/emptyLocations.ts
+++ b/src/modules/wms/services/emptyLocations.ts
@@ -1,0 +1,97 @@
+/**
+ * Empty destination locations, grouped by section.
+ *
+ * Several flows (transfer, put-away) let the operator choose *where to place* an
+ * item. This builds the pool they pick from: locations that are enabled, hold
+ * stock, and are currently empty — grouped by their section (the warehouse area
+ * they sit in) so the dropdown reads like the physical layout.
+ *
+ * Pure and side-effect-free so it is trivial to unit-test and shared by every
+ * screen that needs a destination picker.
+ */
+import type { CellPurpose, Warehouse, WarehouseLocation } from '../types';
+import { findArea, warehouseAreas } from './areas';
+import type { LocationOccupancy } from './occupancy';
+import { locationHoldsStock } from './occupancy';
+
+/** One section (area) of the warehouse with its empty locations. */
+export interface LocationSection {
+  /** Stable key for React lists (`warehouseId:areaKey`). */
+  key: string;
+  /** Human label — the area name, or "Unassigned" when outside every area. */
+  label: string;
+  locations: WarehouseLocation[];
+}
+
+export interface EmptyLocationsInput {
+  locations: readonly WarehouseLocation[];
+  warehouses: readonly Warehouse[];
+  /** Occupancy per location id (see `buildOccupancyIndex`). */
+  occupancy: ReadonlyMap<string, LocationOccupancy>;
+  purposesById?: Map<string, CellPurpose>;
+  /** Never offer this location (e.g. the move's source). */
+  excludeLocationId?: string | null;
+}
+
+/**
+ * Whether a location can currently receive stock: enabled, storage, and holding
+ * nothing at all.
+ *
+ * Emptiness is measured from the stock actually present — NOT from
+ * `occupancyPct`. A percentage can read 0 while stock sits there: it is the max
+ * of the ratios that have a configured maximum, so a bin with `maxPallets: 1`,
+ * no `maxUnits`, and loose units on the floor reports 0%.
+ */
+export function isEmptyDestination(
+  location: WarehouseLocation,
+  occupancy: ReadonlyMap<string, LocationOccupancy>,
+  purposesById?: Map<string, CellPurpose>,
+): boolean {
+  if (location.enabled === false) return false;
+  if (!locationHoldsStock(location, purposesById)) return false;
+  const here = occupancy.get(location.id);
+  if (!here) return true; // nothing recorded against this location
+  return here.units === 0 && here.pallets === 0 && here.weight === 0 && here.volume === 0;
+}
+
+/**
+ * Group every empty destination by its section, sections and codes sorted so the
+ * dropdown is stable and reads naturally (A-2 before A-10).
+ */
+export function groupEmptyLocationsBySection({
+  locations,
+  warehouses,
+  occupancy,
+  purposesById,
+  excludeLocationId,
+}: EmptyLocationsInput): LocationSection[] {
+  const areasByWarehouse = new Map(
+    warehouses.map((warehouse) => [warehouse.id, warehouseAreas(warehouse)]),
+  );
+  const groups = new Map<string, LocationSection>();
+
+  for (const location of locations) {
+    if (excludeLocationId && location.id === excludeLocationId) continue;
+    if (!isEmptyDestination(location, occupancy, purposesById)) continue;
+
+    const areas = areasByWarehouse.get(location.warehouseId) ?? [];
+    const area = findArea(areas, location.column, location.row);
+    const key = area
+      ? `${location.warehouseId}:${area.groupId ?? area.id}`
+      : `${location.warehouseId}:unassigned`;
+    const existing = groups.get(key);
+    if (existing) existing.locations.push(location);
+    else groups.set(key, { key, label: area?.name ?? 'Unassigned', locations: [location] });
+  }
+
+  const sections = [...groups.values()];
+  for (const section of sections) {
+    section.locations.sort((a, b) => a.code.localeCompare(b.code, undefined, { numeric: true }));
+  }
+  return sections.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/** Total empty locations across all sections. */
+export function countEmptyLocations(sections: readonly LocationSection[]): number {
+  return sections.reduce((sum, section) => sum + section.locations.length, 0);
+}

--- a/src/modules/wms/services/index.ts
+++ b/src/modules/wms/services/index.ts
@@ -10,6 +10,12 @@ export {
   warehouseAreas,
 } from './areas';
 export { buildLocationsCsv, parseCsv, parseWarehouseCsv } from './csv';
+export type { EmptyLocationsInput, LocationSection } from './emptyLocations';
+export {
+  countEmptyLocations,
+  groupEmptyLocationsBySection,
+  isEmptyDestination,
+} from './emptyLocations';
 export type {
   CellPurposeInput,
   InventoryInput,


### PR DESCRIPTION
## Audit — where a location is chosen in warehouse-ops

| Page | Location's role | Empty-only dropdown? |
|---|---|---|
| Transfer | destination | already had one (#89) |
| **Receive / Put Away** | destination | **added here** |
| Map (move mode) | destination (tap a cell) | not changed — grid already highlights valid targets |
| Pick | **source** (must hold stock) | no — would list bins with nothing to pick |
| Count | **source** (count what's there) | no |
| Outbound | **source** (pallet's bin) | no |

The separate **`warehouse` module** is read-only dashboards/reports + BST stock-transfer documents; its "destination" fields are *companies/warehouses*, not bins — **no location pickers, nothing to add**.

## Changes
- New shared service `groupEmptyLocationsBySection` — empty destinations grouped by their area, sections + codes sorted naturally. Transfer and Receive now share one implementation.
- **Receive / Put Away**: new "Pick an empty location (N empty)" dropdown grouped by section, restricted to spaces the put-away engine already deemed legal for the item; recommended picks keep their ★.
- **Transfer**: refactored onto the shared service.

## Bug found and fixed by the new tests
"Empty" was derived from `occupancyPct`, which reads **0 for a bin that holds loose units** when only `maxPallets` is configured (the pallet ratio wins and `maxUnits` is null). So occupied bins could be offered as empty — including in the Transfer dropdown shipped in #89. Emptiness is now measured from the **stock actually present** (units/pallets/weight/volume).

## Verification
- 8 new unit tests for the helper (grouping, sorting, exclusions, and the occupancy bug).
- WMS suite: **146 pass** (was 138). Typecheck, lint, build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)