### PR TITLE
fix(wms): deleting a warehouse fails and stays permanently undeletable

### DIFF
--- a/src/modules/wms/__tests__/wms.deleteWarehouse.test.ts
+++ b/src/modules/wms/__tests__/wms.deleteWarehouse.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { get, post, patch, del } = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  del: vi.fn(),
+}));
+
+vi.mock('@/core/api', () => ({ apiClient: { get, post, patch, delete: del } }));
+
+import { ApiAdapter, runWithConcurrency, WRITE_CONCURRENCY } from '../storage/apiAdapter';
+
+beforeEach(() => {
+  get.mockReset();
+  post.mockReset();
+  patch.mockReset();
+  del.mockReset();
+});
+
+const notFound = { response: { status: 404 } };
+
+describe('ApiAdapter.remove — idempotent delete', () => {
+  const adapter = new ApiAdapter();
+
+  it('deletes a record at the right endpoint', async () => {
+    del.mockResolvedValueOnce({});
+    await adapter.remove('locations', 'L1');
+    expect(del).toHaveBeenCalledWith('/wms/locations/L1/');
+  });
+
+  it('treats a 404 as success — the record is already gone', async () => {
+    del.mockRejectedValueOnce(notFound);
+    await expect(adapter.remove('locations', 'gone')).resolves.toBeUndefined();
+  });
+
+  it('still surfaces real failures (e.g. 500)', async () => {
+    del.mockRejectedValueOnce({ response: { status: 500 } });
+    await expect(adapter.remove('locations', 'boom')).rejects.toMatchObject({
+      response: { status: 500 },
+    });
+  });
+
+  it('a half-finished cascade can be retried: already-deleted records no longer throw', async () => {
+    // First pass deleted L1; L2 failed. Retry: L1 → 404, L2 → ok.
+    del.mockRejectedValueOnce(notFound).mockResolvedValueOnce({});
+    await expect(
+      runWithConcurrency([() => adapter.remove('locations', 'L1'), () => adapter.remove('locations', 'L2')]),
+    ).resolves.toHaveLength(2);
+  });
+});
+
+describe('runWithConcurrency', () => {
+  it('never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const tasks = Array.from({ length: 50 }, () => async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return 1;
+    });
+    await runWithConcurrency(tasks, 5);
+    expect(peak).toBeLessThanOrEqual(5);
+  });
+
+  it('preserves result order regardless of completion order', async () => {
+    const tasks = [
+      async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return 'slow';
+      },
+      async () => 'fast',
+    ];
+    expect(await runWithConcurrency(tasks, 2)).toEqual(['slow', 'fast']);
+  });
+
+  it('rejects when a task fails', async () => {
+    const tasks = [async () => 1, async () => Promise.reject(new Error('nope'))];
+    await expect(runWithConcurrency(tasks, 2)).rejects.toThrow('nope');
+  });
+
+  it('handles an empty task list', async () => {
+    expect(await runWithConcurrency([], WRITE_CONCURRENCY)).toEqual([]);
+  });
+});

--- a/src/modules/wms/pages/WmsWarehousesPage.tsx
+++ b/src/modules/wms/pages/WmsWarehousesPage.tsx
@@ -2,10 +2,9 @@
  * Warehouses list (Step 3).
  *
  * Manage saved warehouses — open in the editor, clone, delete (cascading its
- * zones + locations), export a JSON backup, or import one. "New warehouse" opens
- * the designer.
+ * zones, purposes, locations and the stock held in them), export a JSON backup,
+ * or import one. "New warehouse" opens the designer.
  */
-import { useMemo, useRef, useState } from 'react';
 import {
   Copy,
   Download,
@@ -15,6 +14,7 @@ import {
   Upload,
   Warehouse as WarehouseIcon,
 } from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -31,9 +31,8 @@ import {
   DialogTitle,
 } from '@/shared/components/ui';
 
-import { WmsDisabledNotice } from '../components/WmsDisabledNotice';
 import { AdminOnlyNotice } from '../components/AdminOnlyNotice';
-import { useWarehouses, useWmsCollection, useWmsEnabled, useWmsRole, wmsStore } from '../store';
+import { WmsDisabledNotice } from '../components/WmsDisabledNotice';
 import {
   buildWarehouseExport,
   instantiateTemplate,
@@ -41,6 +40,7 @@ import {
   parseWarehouseExport,
   rekeyWarehouseBundle,
 } from '../services';
+import { useWarehouses, useWmsCollection, useWmsEnabled, useWmsRole, wmsStore } from '../store';
 import type { LayoutTemplate, Warehouse } from '../types';
 
 export default function WmsWarehousesPage() {
@@ -97,6 +97,19 @@ export default function WmsWarehousesPage() {
     }
   }
 
+  /** Surface what the server actually said — a bare "Delete failed." hides the cause. */
+  function deleteErrorMessage(error: unknown): string {
+    const response = (error as { response?: { status?: number; data?: unknown } } | null)?.response;
+    const body = response?.data as { error?: string; detail?: string } | undefined;
+    const detail = body?.error || body?.detail;
+    if (detail) return detail;
+    if (response?.status === 403) {
+      return 'You do not have permission to delete everything in this warehouse.';
+    }
+    if (error instanceof Error && error.message) return error.message;
+    return 'Delete failed.';
+  }
+
   async function handleDelete(warehouse: Warehouse) {
     if (!window.confirm(`Delete "${warehouse.name}" and all its locations? This cannot be undone.`)) {
       return;
@@ -106,7 +119,7 @@ export default function WmsWarehousesPage() {
       await wmsStore.deleteWarehouseCascade(warehouse.id);
       toast.success(`Deleted "${warehouse.name}".`);
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Delete failed.');
+      toast.error(deleteErrorMessage(error));
     } finally {
       setBusyId(null);
     }

--- a/src/modules/wms/storage/apiAdapter.ts
+++ b/src/modules/wms/storage/apiAdapter.ts
@@ -37,6 +37,35 @@ function isNotFound(error: unknown): boolean {
   );
 }
 
+/**
+ * How many write requests may be in flight at once. Deleting a warehouse can
+ * touch thousands of records; firing them all at once starves the browser's
+ * connection pool and overloads the server, so a single timeout would fail the
+ * whole cascade.
+ */
+export const WRITE_CONCURRENCY = 8;
+
+/**
+ * Run async tasks with a bounded number in flight. Rejects with the first error
+ * (like `Promise.all`) but never floods the network.
+ */
+export async function runWithConcurrency<T>(
+  tasks: readonly (() => Promise<T>)[],
+  limit = WRITE_CONCURRENCY,
+): Promise<T[]> {
+  const results = new Array<T>(tasks.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, tasks.length) }, async () => {
+    while (next < tasks.length) {
+      const index = next;
+      next += 1;
+      results[index] = await tasks[index]!();
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
 export class ApiAdapter implements WmsStorageAdapter {
   readonly kind = 'api' as const;
 
@@ -82,13 +111,24 @@ export class ApiAdapter implements WmsStorageAdapter {
     return response.data;
   }
 
+  /**
+   * Delete a record. A 404 means it is already gone, which satisfies the intent —
+   * DELETE is idempotent. Without this a cascade that partly failed could never
+   * be retried: the next attempt 404s on the records it already removed, so the
+   * parent (e.g. a warehouse) stays undeletable forever.
+   */
   async remove<K extends WmsCollection>(collection: K, id: WmsId): Promise<void> {
-    await apiClient.delete(collectionUrl(collection, id));
+    try {
+      await apiClient.delete(collectionUrl(collection, id));
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
   }
 
   async clear(collection: WmsCollection): Promise<void> {
     const all = await this.list(collection);
-    await Promise.all(all.map((record) => this.remove(collection, record.id)));
+    await runWithConcurrency(all.map((record) => () => this.remove(collection, record.id)));
   }
 
   async clearAll(): Promise<void> {

--- a/src/modules/wms/storage/index.ts
+++ b/src/modules/wms/storage/index.ts
@@ -1,4 +1,4 @@
 export type { WmsCollection, WmsCollectionMap, WmsStorageAdapter } from './adapter.types';
 export { WMS_COLLECTIONS } from './adapter.types';
-export { ApiAdapter } from './apiAdapter';
+export { ApiAdapter, runWithConcurrency, WRITE_CONCURRENCY } from './apiAdapter';
 export { getActiveWmsAdapter } from './createAdapter';

--- a/src/modules/wms/store/wmsStore.ts
+++ b/src/modules/wms/store/wmsStore.ts
@@ -10,7 +10,7 @@
 import { makeInventoryRecord, makeMovement, makePallet } from '../services/factories';
 import type { WarehouseBundle } from '../services/warehouseIO';
 import type { WmsCollection, WmsCollectionMap, WmsStorageAdapter } from '../storage';
-import { getActiveWmsAdapter } from '../storage';
+import { getActiveWmsAdapter, runWithConcurrency } from '../storage';
 import type { Warehouse, WmsId, WmsSettings } from '../types';
 import { DEFAULT_WMS_SETTINGS, WMS_SETTINGS_ID } from '../types';
 import { nowIso } from '../utils';
@@ -181,31 +181,61 @@ class WmsStore {
     return warehouse;
   }
 
-  /** Delete a warehouse and every zone + location that belongs to it. */
+  /**
+   * Delete a warehouse and everything that belongs to it: its zones, purposes,
+   * locations, and the stock (inventory lines + pallets) sitting in those
+   * locations — which would otherwise be orphaned and corrupt occupancy.
+   *
+   * Deletes run with bounded concurrency: a large warehouse has thousands of
+   * locations, and firing every DELETE at once starved the connection pool, so a
+   * single timeout aborted the cascade and left the warehouse half-deleted (and,
+   * because `remove` used to throw on 404, permanently undeletable on retry).
+   * `remove` is now idempotent, so this whole operation is safe to retry.
+   *
+   * Movements are an append-only audit log and are deliberately kept.
+   */
   async deleteWarehouseCascade(warehouseId: WmsId): Promise<void> {
     const adapter = this.adapter();
-    const [locations, zones, purposes] = await Promise.all([
+    const [locations, zones, purposes, inventory, pallets] = await Promise.all([
       adapter.list('locations'),
       adapter.list('zones'),
       adapter.list('cellPurposes'),
+      adapter.list('inventory'),
+      adapter.list('pallets'),
     ]);
-    await Promise.all([
-      ...locations
-        .filter((location) => location.warehouseId === warehouseId)
-        .map((location) => adapter.remove('locations', location.id)),
+
+    const doomedLocations = locations.filter((location) => location.warehouseId === warehouseId);
+    const doomedLocationIds = new Set(doomedLocations.map((location) => location.id));
+
+    // Stock first, then the locations it pointed at, then the warehouse itself.
+    await runWithConcurrency(
+      inventory
+        .filter((record) => doomedLocationIds.has(record.locationId))
+        .map((record) => () => adapter.remove('inventory', record.id)),
+    );
+    await runWithConcurrency(
+      pallets
+        .filter((pallet) => pallet.currentLocationId && doomedLocationIds.has(pallet.currentLocationId))
+        .map((pallet) => () => adapter.remove('pallets', pallet.id)),
+    );
+    await runWithConcurrency([
+      ...doomedLocations.map((location) => () => adapter.remove('locations', location.id)),
       ...zones
         .filter((zone) => zone.warehouseId === warehouseId)
-        .map((zone) => adapter.remove('zones', zone.id)),
+        .map((zone) => () => adapter.remove('zones', zone.id)),
       ...purposes
         .filter((purpose) => purpose.warehouseId === warehouseId)
-        .map((purpose) => adapter.remove('cellPurposes', purpose.id)),
+        .map((purpose) => () => adapter.remove('cellPurposes', purpose.id)),
     ]);
     await adapter.remove('warehouses', warehouseId);
+
     await Promise.all([
       this.load('warehouses'),
       this.load('zones'),
       this.load('cellPurposes'),
       this.load('locations'),
+      this.load('inventory'),
+      this.load('pallets'),
     ]);
   }
 


### PR DESCRIPTION
Deleting a warehouse (e.g. "Gupta Gadown") showed an error — and once it failed, it could **never** succeed.

## Root cause
`deleteWarehouseCascade` fired an **unbounded `Promise.all`** of one `DELETE` per record. A large warehouse has thousands of locations, so this starved the browser's connection pool and hammered the API. A single timeout rejected the whole batch — **after many locations had already been deleted**. The warehouse itself is removed *after* that batch, so it was never removed: the warehouse was left half-deleted.

On the next attempt, those already-deleted locations returned **404**, and `ApiAdapter.remove` **threw on 404** (unlike `get`, which tolerates it). So the cascade failed again, forever. The warehouse became **permanently undeletable**.

Not a permissions problem: the `WMS Admin` group is granted every `wms.*` permission, and only admins see the delete button.

## Fix
- **`ApiAdapter.remove` treats 404 as success.** DELETE is idempotent — a record that's already gone satisfies the intent. This alone makes the cascade retryable, unsticking existing broken warehouses.
- **`runWithConcurrency` caps writes at 8 in flight**, so a big warehouse no longer floods the network and times out.
- **The cascade now also deletes the inventory lines and pallets** held in the deleted locations. Previously these were orphaned, pointing at locations that no longer exist, corrupting occupancy. (Movements are an append-only audit log and are deliberately kept.)
- **Delete errors now surface the server's message** (plus a clear 403 hint) instead of a bare "Delete failed."

## Verification
- 8 new tests: idempotent 404 delete, real errors (500) still surface, the **retry-after-partial-failure** path, and that concurrency never exceeds the cap (plus order preservation and empty-list handling).
- WMS suite: **154 pass** (was 146). Typecheck, lint, build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)