### PR TITLE
feat(wms): pallet-first Receive, BST→WMS putaway & richer map

### DIFF
--- a/src/config/constants/api.constants.ts
+++ b/src/config/constants/api.constants.ts
@@ -857,6 +857,7 @@ export const API_ENDPOINTS = {
     DISPATCH_REPORT_REJECTED_SCANS: '/barcode/dispatch/reports/rejected-scans/',
     // Production Integration
     OITM_ITEMS: '/barcode/items/oitm/',
+    OITM_ITEM_DETAIL: '/barcode/items/oitm/detail/',
     PRODUCTION_RELEASE_OIL: '/barcode/production-release-oil/',
     PRODUCTION_LABELS: (runId: number) => `/barcode/production/${runId}/generate-labels/`,
     PRODUCTION_PALLET: (runId: number) => `/barcode/production/${runId}/create-pallet/`,

--- a/src/modules/barcode/api/barcode.api.ts
+++ b/src/modules/barcode/api/barcode.api.ts
@@ -42,6 +42,7 @@ import type {
   LookupResponse,
   LooseStock,
   LooseStockFilters,
+  OitmItemGroup,
   OitmItemRow,
   PaginatedResponse,
   Pallet,
@@ -374,6 +375,19 @@ export const barcodeApi = {
   async getOitmItems(params?: { search?: string; limit?: number }): Promise<OitmItemRow[]> {
     const res = await apiClient.get<OitmItemRow[]>(EP.OITM_ITEMS, { params });
     return res.data;
+  },
+
+  /** One item's group (code + name) by exact item code; null when not found. */
+  async getOitmItemGroup(itemCode: string): Promise<OitmItemGroup | null> {
+    try {
+      const res = await apiClient.get<OitmItemGroup>(EP.OITM_ITEM_DETAIL, {
+        params: { item_code: itemCode },
+      });
+      return res.data ?? null;
+    } catch {
+      // Best-effort lookup (item not in SAP, or HANA unavailable) — no type shown.
+      return null;
+    }
   },
 
   // =========================================================================

--- a/src/modules/barcode/types/barcode.types.ts
+++ b/src/modules/barcode/types/barcode.types.ts
@@ -380,6 +380,14 @@ export interface OitmItemRow {
   frozen_for: boolean;
 }
 
+/** One item's group (code + name), looked up by exact item code. */
+export interface OitmItemGroup {
+  item_code: string;
+  item_name: string;
+  item_group_code: number | null;
+  item_group_name: string;
+}
+
 export interface VoidPayload {
   reason?: string;
 }

--- a/src/modules/warehouse/pages/bst/BSTPalletPutawayDialog.tsx
+++ b/src/modules/warehouse/pages/bst/BSTPalletPutawayDialog.tsx
@@ -1,0 +1,200 @@
+/**
+ * Assign a Warehouse Ops (bin-level WMS) location to a pallet received on a BST.
+ *
+ * Bridges the BST receive flow into the WMS: it resolves the destination
+ * warehouse (a stock transfer's `sap_to_warehouse`, or an operator pick for an
+ * invoice), offers the same smart putaway picker as the WMS Receive page, and on
+ * confirm places the pallet — creating a WMS Pallet + Inventory + PUTAWAY
+ * movement via the external-pallet bridge (`syncExternalPalletPlacement`, keyed
+ * by the pallet's license plate).
+ */
+import { Loader2, PackagePlus } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import { PutawayBinPicker, type PutawaySelection } from '@/modules/wms/components/PutawayBinPicker';
+import type { MoveItem } from '@/modules/wms/services';
+import { useWmsCollection, wmsStore } from '@/modules/wms/store';
+import { Button, Label, NativeSelect } from '@/shared/components/ui';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
+import { getErrorMessage } from '@/shared/utils';
+
+import type { BSTTransferDetail } from '../../types';
+import type { BstReceivedPallet } from './bstReceivePallets';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pallet: BstReceivedPallet | null;
+  transfer: BSTTransferDetail;
+  /** Called after a successful placement (parent can refresh / close). */
+  onPlaced: () => void;
+}
+
+function sameCode(a?: string | null, b?: string | null): boolean {
+  return (a ?? '').trim().toLowerCase() === (b ?? '').trim().toLowerCase();
+}
+
+export function BSTPalletPutawayDialog({ open, onOpenChange, pallet, transfer, onPlaced }: Props) {
+  const { data: warehouses } = useWmsCollection('warehouses');
+
+  const ownWarehouses = useMemo(
+    () => warehouses.filter((wh) => (wh.type ?? 'OWN') === 'OWN'),
+    [warehouses],
+  );
+
+  // A stock transfer has a concrete destination warehouse (`sap_to_warehouse`);
+  // an invoice does not (destination is a company), so the operator picks one.
+  const preferredCode = useMemo(
+    () =>
+      transfer.source_type === 'STOCK_TRANSFER'
+        ? transfer.sap_to_warehouse || pallet?.warehouseCode || ''
+        : '',
+    [transfer.source_type, transfer.sap_to_warehouse, pallet?.warehouseCode],
+  );
+
+  const defaultWarehouseId = useMemo(() => {
+    const matched = preferredCode
+      ? ownWarehouses.find((wh) => sameCode(wh.sapWarehouseCode, preferredCode))
+      : null;
+    return matched?.id ?? ownWarehouses[0]?.id ?? '';
+  }, [ownWarehouses, preferredCode]);
+
+  const [warehouseOverride, setWarehouseOverride] = useState<string | null>(null);
+  const [selection, setSelection] = useState<PutawaySelection>({ location: null, validation: null });
+  const [busy, setBusy] = useState(false);
+
+  const warehouseId = warehouseOverride ?? defaultWarehouseId;
+
+  // Fresh state whenever a different pallet is opened.
+  useEffect(() => {
+    setWarehouseOverride(null);
+    setSelection({ location: null, validation: null });
+    setBusy(false);
+  }, [pallet?.palletCode, open]);
+
+  const item: MoveItem = useMemo(
+    () => ({
+      itemCode: pallet?.itemCode ?? '',
+      materialType: '',
+      temperatureClass: null,
+      hazmatClass: '',
+      lotNumber: pallet?.batchNumber ?? '',
+      serialNumber: '',
+      expiryDate: null,
+    }),
+    [pallet],
+  );
+  const added = useMemo(
+    () => ({ pallets: 1, units: pallet?.quantity ?? 0, weight: 0, volume: 0 }),
+    [pallet],
+  );
+
+  async function confirm() {
+    if (!pallet || !selection.location || !selection.validation?.ok) return;
+    setBusy(true);
+    try {
+      await wmsStore.syncExternalPalletPlacement({
+        licensePlate: pallet.palletCode,
+        toLocationId: selection.location.id,
+        itemCode: pallet.itemCode,
+        itemName: pallet.itemName,
+        lotNumber: pallet.batchNumber,
+        boxCount: pallet.boxCount,
+        totalUnits: pallet.quantity,
+        uom: pallet.uom,
+        note: `BST ${transfer.entry_no} receive putaway`,
+      });
+      toast.success(`Pallet ${pallet.palletCode} placed in ${selection.location.code}.`);
+      onPlaced();
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Could not assign location'));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const showWarehousePicker = ownWarehouses.length > 1 || transfer.source_type === 'INVOICE';
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !busy && onOpenChange(next)}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Assign a Warehouse Ops location</DialogTitle>
+        </DialogHeader>
+
+        {!pallet ? null : ownWarehouses.length === 0 ? (
+          <p className="rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+            No Warehouse Ops warehouse is configured for this company. Design one (with a matching SAP
+            warehouse code) before assigning locations.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {/* Pallet summary */}
+            <div className="rounded-md border bg-muted/30 px-3 py-2.5 text-sm">
+              <p className="font-medium">
+                Pallet <span className="font-mono">{pallet.palletCode}</span>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {pallet.itemName || pallet.itemCode} · {pallet.boxCount} box
+                {pallet.boxCount === 1 ? '' : 'es'} · {pallet.quantity} {pallet.uom}
+                {pallet.batchNumber ? ` · lot ${pallet.batchNumber}` : ''}
+              </p>
+            </div>
+
+            {showWarehousePicker ? (
+              <div className="space-y-1.5">
+                <Label htmlFor="bst-putaway-warehouse">Warehouse</Label>
+                <NativeSelect
+                  id="bst-putaway-warehouse"
+                  value={warehouseId}
+                  onChange={(event) => {
+                    setWarehouseOverride(event.target.value);
+                    setSelection({ location: null, validation: null });
+                  }}
+                >
+                  {ownWarehouses.map((wh) => (
+                    <option key={wh.id} value={wh.id}>
+                      {wh.name}
+                    </option>
+                  ))}
+                </NativeSelect>
+              </div>
+            ) : null}
+
+            {warehouseId ? (
+              <PutawayBinPicker
+                warehouseId={warehouseId}
+                item={item}
+                quantity={pallet.quantity}
+                added={added}
+                selectedLocationId={selection.location?.id ?? null}
+                onChange={setSelection}
+              />
+            ) : null}
+
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+                Cancel
+              </Button>
+              <Button onClick={() => void confirm()} disabled={busy || !selection.validation?.ok}>
+                {busy ? (
+                  <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                ) : (
+                  <PackagePlus className="mr-1 h-4 w-4" />
+                )}
+                Place in {selection.location?.code ?? 'location'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/warehouse/pages/bst/BSTReceivePage.tsx
+++ b/src/modules/warehouse/pages/bst/BSTReceivePage.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { useScanner } from '@/modules/barcode/hooks/useScanner';
+import { WmsEnabledGate } from '@/modules/wms/components/WmsEnabledGate';
 import { DashboardHeader } from '@/shared/components/dashboard/DashboardHeader';
 import { Badge, Button, Card, CardContent, Input } from '@/shared/components/ui';
 import {
@@ -16,9 +17,10 @@ import {
 import { useBoxScanQueue } from '@/shared/hooks';
 import { cn, getErrorMessage } from '@/shared/utils';
 
-import { bstApi, BST_QUERY_KEYS, useBSTIncomingDetail, useCompleteBSTReceive } from '../../api';
+import { BST_QUERY_KEYS, bstApi, useBSTIncomingDetail, useCompleteBSTReceive } from '../../api';
 import type { BSTReceiveStatus } from '../../types';
 import { BoxScanCamera } from './BoxScanCamera';
+import { BSTReceivePutawaySection } from './BSTReceivePutawaySection';
 import { BSTStatusBadge } from './bstStatus';
 
 const RECEIVABLE = ['IN_TRANSIT', 'ARRIVED', 'RECEIVING'];
@@ -290,6 +292,11 @@ export default function BSTReceivePage() {
           )}
         </CardContent>
       </Card>
+
+      {/* Put away received pallets into Warehouse Ops bins (only when WMS is on). */}
+      <WmsEnabledGate fallback={null}>
+        <BSTReceivePutawaySection transfer={transfer} />
+      </WmsEnabledGate>
 
       {receivable && (
         <div className="flex justify-end gap-2">

--- a/src/modules/warehouse/pages/bst/BSTReceivePutawaySection.test.ts
+++ b/src/modules/warehouse/pages/bst/BSTReceivePutawaySection.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BSTBoxScan } from '../../types';
+import { groupAcceptedPallets } from './bstReceivePallets';
+
+/** Minimal BSTBoxScan builder — only the fields the grouping reads matter. */
+function scan(overrides: Partial<BSTBoxScan>): BSTBoxScan {
+  return {
+    id: Math.floor(Math.random() * 1e9),
+    box: null,
+    pallet: null,
+    box_barcode: 'BX',
+    item_code: 'ITEM1',
+    item_name: 'Item One',
+    batch_number: 'B1',
+    quantity: '10',
+    uom: 'EA',
+    warehouse_code: 'WH1',
+    pallet_code: '',
+    scanned_by_name: '',
+    scanned_at: '',
+    receive_status: 'ACCEPTED',
+    reject_reason: '',
+    is_unexpected: false,
+    received_by_name: '',
+    received_at: null,
+    ...overrides,
+  };
+}
+
+describe('groupAcceptedPallets', () => {
+  it('groups accepted boxes by pallet, summing box count and quantity', () => {
+    const result = groupAcceptedPallets([
+      scan({ pallet_code: 'PLT-1', quantity: '10' }),
+      scan({ pallet_code: 'PLT-1', quantity: '5' }),
+      scan({ pallet_code: 'PLT-2', quantity: '7' }),
+    ]);
+    expect(result).toHaveLength(2);
+    const plt1 = result.find((p) => p.palletCode === 'PLT-1')!;
+    expect(plt1.boxCount).toBe(2);
+    expect(plt1.quantity).toBe(15);
+    expect(result.find((p) => p.palletCode === 'PLT-2')!.quantity).toBe(7);
+  });
+
+  it('ignores non-accepted scans and loose boxes with no pallet', () => {
+    const result = groupAcceptedPallets([
+      scan({ pallet_code: 'PLT-1' }),
+      scan({ pallet_code: 'PLT-9', receive_status: 'REJECTED' }),
+      scan({ pallet_code: 'PLT-8', receive_status: 'PENDING' }),
+      scan({ pallet_code: '' }), // loose box
+    ]);
+    expect(result.map((p) => p.palletCode)).toEqual(['PLT-1']);
+  });
+
+  it('falls back to the box count when boxes carry no unit quantity', () => {
+    const result = groupAcceptedPallets([
+      scan({ pallet_code: 'PLT-1', quantity: '0' }),
+      scan({ pallet_code: 'PLT-1', quantity: '' }),
+    ]);
+    expect(result[0].quantity).toBe(2); // 0 units → fall back to 2 boxes
+    expect(result[0].boxCount).toBe(2);
+  });
+
+  it('carries item identity from the first box of each pallet', () => {
+    const [pallet] = groupAcceptedPallets([
+      scan({ pallet_code: 'PLT-1', item_code: 'OIL', item_name: 'Jivo Oil', uom: 'CTN', batch_number: 'L42' }),
+    ]);
+    expect(pallet).toMatchObject({
+      palletCode: 'PLT-1',
+      itemCode: 'OIL',
+      itemName: 'Jivo Oil',
+      uom: 'CTN',
+      batchNumber: 'L42',
+    });
+  });
+});

--- a/src/modules/warehouse/pages/bst/BSTReceivePutawaySection.tsx
+++ b/src/modules/warehouse/pages/bst/BSTReceivePutawaySection.tsx
@@ -1,0 +1,126 @@
+/**
+ * "Put away received pallets" — the WMS bridge shown on the BST receive page.
+ *
+ * Groups the transfer's ACCEPTED box scans by pallet and lets the operator drop
+ * each received pallet into a Warehouse Ops bin (see BSTPalletPutawayDialog). It
+ * is mounted only when the WMS master flag is on (its parent wraps it in
+ * WmsEnabledGate), so the WMS collections load only for companies that use it.
+ *
+ * Placement status is read back from the WMS `pallets` collection (by plate), so
+ * it survives reloads without persisting anything on the BST side.
+ */
+import { MapPin, PackageCheck } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { useAppSelector } from '@/core/store';
+import { useWmsCollection } from '@/modules/wms/store';
+import { Badge, Button, Card, CardContent } from '@/shared/components/ui';
+
+import type { BSTTransferDetail } from '../../types';
+import { BSTPalletPutawayDialog } from './BSTPalletPutawayDialog';
+import { type BstReceivedPallet, groupAcceptedPallets } from './bstReceivePallets';
+
+export function BSTReceivePutawaySection({ transfer }: { transfer: BSTTransferDetail }) {
+  const currentCompany = useAppSelector((state) => state.auth.currentCompany);
+  const { data: wmsPallets } = useWmsCollection('pallets');
+  const { data: locations } = useWmsCollection('locations');
+
+  const [putawayPallet, setPutawayPallet] = useState<BstReceivedPallet | null>(null);
+
+  const receivedPallets = useMemo(
+    () => groupAcceptedPallets(transfer.box_scans),
+    [transfer.box_scans],
+  );
+
+  // Where each plate currently sits in WMS — durable status across reloads.
+  const placedByPlate = useMemo(() => {
+    const codeByLocation = new Map(locations.map((l) => [l.id, l.code]));
+    const map = new Map<string, string>();
+    for (const pallet of wmsPallets) {
+      if (!pallet.currentLocationId || pallet.status === 'SHIPPED') continue;
+      const code = codeByLocation.get(pallet.currentLocationId);
+      if (code) map.set(pallet.licensePlate.trim().toLowerCase(), code);
+    }
+    return map;
+  }, [wmsPallets, locations]);
+
+  // WMS data is scoped to the ACTIVE company. For an invoice (cross-company) BST
+  // the receiving company differs from the sender, so putaway must happen while
+  // the destination company is active — otherwise we'd write to the wrong tenant.
+  const receivingCompanyCode =
+    transfer.source_type === 'INVOICE' ? transfer.destination_company_code : transfer.company_code;
+  const receivingCompanyName =
+    transfer.source_type === 'INVOICE' ? transfer.destination_company_name : transfer.company_name;
+  const companyMismatch = Boolean(
+    receivingCompanyCode &&
+      currentCompany?.company_code &&
+      receivingCompanyCode.trim().toLowerCase() !== currentCompany.company_code.trim().toLowerCase(),
+  );
+
+  if (receivedPallets.length === 0) return null;
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="mb-3 flex items-center gap-2">
+          <PackageCheck className="h-4 w-4 text-muted-foreground" />
+          <p className="font-medium">Put away received pallets</p>
+        </div>
+
+        {companyMismatch ? (
+          <p className="mb-3 rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+            Switch to{' '}
+            <span className="font-medium">{receivingCompanyName || receivingCompanyCode}</span> to
+            assign Warehouse Ops locations for this transfer.
+          </p>
+        ) : null}
+
+        <div className="space-y-1">
+          {receivedPallets.map((pallet) => {
+            const placedCode = placedByPlate.get(pallet.palletCode.trim().toLowerCase());
+            return (
+              <div
+                key={pallet.palletCode}
+                className="flex items-center justify-between gap-3 border-b py-2 text-sm last:border-b-0"
+              >
+                <div className="min-w-0">
+                  <p className="truncate font-medium">
+                    <span className="font-mono">{pallet.palletCode}</span>{' '}
+                    <span className="text-muted-foreground">· {pallet.itemName || pallet.itemCode}</span>
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {pallet.boxCount} box{pallet.boxCount === 1 ? '' : 'es'} · {pallet.quantity}{' '}
+                    {pallet.uom}
+                  </p>
+                </div>
+                {placedCode ? (
+                  <Badge variant="outline" className="shrink-0 text-emerald-700">
+                    <MapPin className="mr-1 h-3 w-3" /> {placedCode}
+                  </Badge>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 shrink-0"
+                    disabled={companyMismatch}
+                    onClick={() => setPutawayPallet(pallet)}
+                  >
+                    <MapPin className="mr-1 h-3 w-3" /> Assign location
+                  </Button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+
+      <BSTPalletPutawayDialog
+        open={putawayPallet !== null}
+        onOpenChange={(next) => !next && setPutawayPallet(null)}
+        pallet={putawayPallet}
+        transfer={transfer}
+        onPlaced={() => setPutawayPallet(null)}
+      />
+    </Card>
+  );
+}

--- a/src/modules/warehouse/pages/bst/bstReceivePallets.ts
+++ b/src/modules/warehouse/pages/bst/bstReceivePallets.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure helpers for the BST → Warehouse Ops putaway bridge.
+ *
+ * Kept out of the component files so both the section and the dialog can share
+ * the received-pallet shape and grouping without tripping react-refresh's
+ * "only export components" rule.
+ */
+import type { BSTBoxScan } from '../../types';
+
+/** A pallet accepted on a BST receive, ready to be put away into a WMS bin. */
+export interface BstReceivedPallet {
+  /** License plate (barcode `pallet_id`) — the WMS bridge keys on this. */
+  palletCode: string;
+  itemCode: string;
+  itemName: string;
+  batchNumber: string;
+  uom: string;
+  boxCount: number;
+  /** Total units across the pallet's accepted boxes. */
+  quantity: number;
+  /** The pallet's current warehouse code (from the box scans). */
+  warehouseCode: string;
+}
+
+/** Collapse the ACCEPTED, palletised box scans into one row per pallet. */
+export function groupAcceptedPallets(scans: BSTBoxScan[]): BstReceivedPallet[] {
+  const byPlate = new Map<string, BstReceivedPallet>();
+  for (const scan of scans) {
+    if (scan.receive_status !== 'ACCEPTED') continue;
+    const plate = (scan.pallet_code || '').trim();
+    if (!plate) continue; // loose boxes (no pallet) are out of scope
+    const qty = Number(scan.quantity) || 0;
+    const existing = byPlate.get(plate);
+    if (existing) {
+      existing.boxCount += 1;
+      existing.quantity += qty;
+    } else {
+      byPlate.set(plate, {
+        palletCode: plate,
+        itemCode: scan.item_code,
+        itemName: scan.item_name,
+        batchNumber: scan.batch_number,
+        uom: scan.uom,
+        boxCount: 1,
+        quantity: qty,
+        warehouseCode: scan.warehouse_code,
+      });
+    }
+  }
+  // If a pallet's boxes carried no unit quantity, fall back to the box count so
+  // the putaway engine still has a positive quantity to place.
+  for (const pallet of byPlate.values()) {
+    if (pallet.quantity <= 0) pallet.quantity = pallet.boxCount;
+  }
+  return [...byPlate.values()];
+}

--- a/src/modules/wms/components/LocationDetailPanel.tsx
+++ b/src/modules/wms/components/LocationDetailPanel.tsx
@@ -58,6 +58,49 @@ function Usage({ label, used, max, unit }: { label: string; used: number; max: n
   );
 }
 
+/** One label/value row in the location Details section. */
+function Detail({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex justify-between gap-3 text-sm">
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <span className="text-right font-medium">{value}</span>
+    </div>
+  );
+}
+
+/** ISO datetime → plain date (drop the time part). */
+function asDate(value: string | null | undefined): string {
+  return value && value.length >= 10 ? value.slice(0, 10) : value ?? '';
+}
+
+/** A human item label that never falls back to the pallet plate. */
+function itemLabel(itemName: string, itemCode: string, plate?: string): string {
+  if (itemName.trim()) return itemName;
+  if (itemCode.trim() && itemCode !== plate) return itemCode;
+  return 'Unknown item';
+}
+
+/** The location's configured constraints, as {label, value} rows (empty when none). */
+function locationDetails(location: WarehouseLocation): { label: string; value: React.ReactNode }[] {
+  const rows: { label: string; value: React.ReactNode }[] = [];
+  if (location.status && location.status !== 'ACTIVE') rows.push({ label: 'Status', value: location.status });
+  if (location.barcode && location.barcode !== location.code) rows.push({ label: 'Barcode', value: location.barcode });
+  const rules = location.materialRules;
+  if (rules?.temperatureClass) rows.push({ label: 'Temperature', value: rules.temperatureClass });
+  if (rules?.singleLotOnly) rows.push({ label: 'Single lot only', value: 'Yes' });
+  if (rules && rules.allowMixedItems === false) rows.push({ label: 'Mixed items', value: 'Not allowed' });
+  if (rules?.allowedMaterialTypes?.length) rows.push({ label: 'Allowed types', value: rules.allowedMaterialTypes.join(', ') });
+  if (rules?.restrictedMaterialTypes?.length) rows.push({ label: 'Restricted types', value: rules.restrictedMaterialTypes.join(', ') });
+  if (rules?.hazmatAllowed) rows.push({ label: 'Hazmat', value: rules.hazmatClasses?.length ? rules.hazmatClasses.join(', ') : 'Allowed' });
+  if (location.reservation?.isReserved) rows.push({ label: 'Reserved for', value: location.reservation.reference || 'Yes' });
+  const rep = location.replenishment;
+  if (rep && (rep.minStock != null || rep.maxStock != null)) {
+    rows.push({ label: 'Min / max stock', value: `${rep.minStock ?? '—'} / ${rep.maxStock ?? '—'}` });
+  }
+  if (location.notes?.trim()) rows.push({ label: 'Notes', value: location.notes });
+  return rows;
+}
+
 export function LocationDetailPanel({
   open,
   onOpenChange,
@@ -72,6 +115,7 @@ export function LocationDetailPanel({
   if (!location) return null;
   const meta = occupancy ? DISPLAY_STATUS_META[occupancy.status] : null;
   const isStorage = purpose ? purpose.holdsStock : true;
+  const details = locationDetails(location);
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -124,6 +168,18 @@ export function LocationDetailPanel({
             </section>
           ) : null}
 
+          {/* Location configuration & constraints */}
+          {details.length > 0 ? (
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold">Details</h3>
+              <div className="space-y-1.5">
+                {details.map((row) => (
+                  <Detail key={row.label} label={row.label} value={row.value} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
           <Separator />
 
           {/* Pallets inside */}
@@ -133,30 +189,46 @@ export function LocationDetailPanel({
               <p className="text-sm text-muted-foreground">No pallets here yet.</p>
             ) : (
               palletsHere.map((pallet) => (
-                <div key={pallet.id} className="flex items-center justify-between gap-2 rounded-md border p-2 text-sm">
-                  <div className="min-w-0">
-                    <p className="truncate font-medium">{pallet.licensePlate}</p>
-                    <p className="truncate text-xs text-muted-foreground">
-                      {pallet.itemName || pallet.itemCode} · {pallet.boxCount} boxes
-                    </p>
+                <div key={pallet.id} className="rounded-md border p-2 text-sm">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">
+                        {itemLabel(pallet.itemName, pallet.itemCode, pallet.licensePlate)}
+                      </p>
+                      <p className="truncate font-mono text-xs text-muted-foreground">
+                        {pallet.licensePlate}
+                        {pallet.itemCode && pallet.itemCode !== pallet.licensePlate
+                          ? ` · ${pallet.itemCode}`
+                          : ''}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      <WmsPrintLabelButton
+                        label="Print"
+                        documentTitle={`Pallet ${pallet.licensePlate}`}
+                        labels={[
+                          {
+                            code: pallet.licensePlate,
+                            title: pallet.licensePlate,
+                            heading: 'PALLET',
+                            subtitle: itemLabel(pallet.itemName, pallet.itemCode, pallet.licensePlate),
+                          },
+                        ]}
+                      />
+                      {onMovePallet ? (
+                        <Button variant="outline" size="sm" onClick={() => onMovePallet(pallet)}>
+                          <MoveRight className="mr-1 h-3.5 w-3.5" /> Move
+                        </Button>
+                      ) : null}
+                    </div>
                   </div>
-                  <div className="flex shrink-0 items-center gap-1.5">
-                    <WmsPrintLabelButton
-                      label="Print"
-                      documentTitle={`Pallet ${pallet.licensePlate}`}
-                      labels={[
-                        {
-                          code: pallet.licensePlate,
-                          title: pallet.licensePlate,
-                          heading: 'PALLET',
-                          subtitle: pallet.itemName || pallet.itemCode,
-                        },
-                      ]}
-                    />
-                    {onMovePallet ? (
-                      <Button variant="outline" size="sm" onClick={() => onMovePallet(pallet)}>
-                        <MoveRight className="mr-1 h-3.5 w-3.5" /> Move
-                      </Button>
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                    <span>{pallet.boxCount} box{pallet.boxCount === 1 ? '' : 'es'}</span>
+                    {pallet.totalUnits ? <span>{pallet.totalUnits} units</span> : null}
+                    {pallet.lotNumber ? <span>lot {pallet.lotNumber}</span> : null}
+                    {pallet.expiryDate ? <span>exp {asDate(pallet.expiryDate)}</span> : null}
+                    {pallet.status && pallet.status !== 'ACTIVE' ? (
+                      <span className="font-medium text-amber-600">{pallet.status}</span>
                     ) : null}
                   </div>
                 </div>
@@ -171,11 +243,19 @@ export function LocationDetailPanel({
               <p className="text-sm text-muted-foreground">No stock here yet.</p>
             ) : (
               inventoryHere.map((record) => (
-                <div key={record.id} className="flex justify-between rounded-md border p-2 text-sm">
-                  <span>{record.itemName || record.itemCode}</span>
-                  <span className="font-medium">
-                    {record.quantity} {record.uom}
-                  </span>
+                <div key={record.id} className="rounded-md border p-2 text-sm">
+                  <div className="flex justify-between gap-2">
+                    <span className="truncate">{itemLabel(record.itemName, record.itemCode)}</span>
+                    <span className="shrink-0 font-medium">
+                      {record.quantity} {record.uom}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                    {record.itemCode ? <span className="font-mono">{record.itemCode}</span> : null}
+                    {record.boxCount ? <span>{record.boxCount} box{record.boxCount === 1 ? '' : 'es'}</span> : null}
+                    {record.lotNumber ? <span>lot {record.lotNumber}</span> : null}
+                    {record.expiryDate ? <span>exp {asDate(record.expiryDate)}</span> : null}
+                  </div>
                 </div>
               ))
             )}

--- a/src/modules/wms/components/PutawayBinPicker.tsx
+++ b/src/modules/wms/components/PutawayBinPicker.tsx
@@ -1,0 +1,300 @@
+/**
+ * Reusable directed-putaway bin picker.
+ *
+ * The "choose a space" half of the WMS Receive flow, extracted so other screens
+ * (e.g. the BST receive page) can offer the same smart destination picker: the
+ * putaway engine ranks every legal bin (★ = recommended), an empty-by-section
+ * dropdown, and search / scan-a-bin. Controlled — the parent owns the selected
+ * location id and is told the resolved location + its validation on every change,
+ * so it can gate its own confirm button.
+ */
+import { Sparkles } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import { Input, Label, NativeSelect } from '@/shared/components/ui';
+
+import type { MoveItem, PutawaySuggestion, ValidationResult } from '../services';
+import {
+  buildOccupancyIndex,
+  countEmptyLocations,
+  groupEmptyLocationsBySection,
+  locationHoldsStock,
+  outsideLocationIds,
+  suggestPutaway,
+  validateMove,
+} from '../services';
+import { useWarehouses, useWmsCollection, useWmsSettings } from '../store';
+import type { WarehouseLocation } from '../types';
+import { WmsScanButton } from './WmsScanButton';
+
+export interface PutawaySelection {
+  location: WarehouseLocation | null;
+  validation: ValidationResult | null;
+}
+
+interface PutawayBinPickerProps {
+  /** The warehouse whose bins are offered. */
+  warehouseId: string;
+  item: MoveItem;
+  /** Total units being put away (drives capacity ranking/validation). */
+  quantity: number;
+  added: { pallets: number; units: number; weight: number; volume: number };
+  selectedLocationId: string | null;
+  onChange: (selection: PutawaySelection) => void;
+}
+
+const SPACE_LIMIT = 90;
+
+export function PutawayBinPicker({
+  warehouseId,
+  item,
+  quantity,
+  added,
+  selectedLocationId,
+  onChange,
+}: PutawayBinPickerProps) {
+  const { settings } = useWmsSettings();
+  const { warehouses } = useWarehouses();
+  const { data: locations } = useWmsCollection('locations');
+  const { data: purposes } = useWmsCollection('cellPurposes');
+  const { data: inventory } = useWmsCollection('inventory');
+  const { data: pallets } = useWmsCollection('pallets');
+
+  const [spaceQuery, setSpaceQuery] = useState('');
+
+  const warehouseLocations = useMemo(
+    () => locations.filter((location) => location.warehouseId === warehouseId),
+    [locations, warehouseId],
+  );
+  const activeWarehouse = useMemo(
+    () => warehouses.find((wh) => wh.id === warehouseId) ?? null,
+    [warehouses, warehouseId],
+  );
+  const outsideIds = useMemo(
+    () =>
+      activeWarehouse
+        ? outsideLocationIds(activeWarehouse, warehouseLocations)
+        : new Set<string>(),
+    [activeWarehouse, warehouseLocations],
+  );
+  const purposeById = useMemo(
+    () => new Map(purposes.map((purpose) => [purpose.id, purpose])),
+    [purposes],
+  );
+
+  const ready = item.itemCode.trim().length > 0 && quantity > 0;
+
+  // Every legal destination for this item, ranked best-first.
+  const availableSpaces: PutawaySuggestion[] = useMemo(() => {
+    if (!ready || !settings) return [];
+    return suggestPutaway({
+      settings,
+      item,
+      quantity,
+      added,
+      locations: warehouseLocations.filter((l) => !outsideIds.has(l.id)),
+      inventory,
+      pallets,
+      purposesById: purposeById,
+      limit: warehouseLocations.length,
+    });
+  }, [ready, settings, item, quantity, added, warehouseLocations, inventory, pallets, purposeById, outsideIds]);
+
+  const recommendedIds = useMemo(
+    () => new Set(availableSpaces.slice(0, 3).map((s) => s.location.id)),
+    [availableSpaces],
+  );
+
+  const occupancy = useMemo(
+    () => buildOccupancyIndex(warehouseLocations, inventory, pallets, purposeById),
+    [warehouseLocations, inventory, pallets, purposeById],
+  );
+
+  const emptyBySection = useMemo(() => {
+    const legalIds = new Set(availableSpaces.map((space) => space.location.id));
+    return groupEmptyLocationsBySection({
+      locations: warehouseLocations.filter((location) => legalIds.has(location.id)),
+      warehouses,
+      occupancy,
+      purposesById: purposeById,
+    });
+  }, [availableSpaces, warehouseLocations, warehouses, occupancy, purposeById]);
+
+  const totalEmpty = useMemo(() => countEmptyLocations(emptyBySection), [emptyBySection]);
+
+  const filteredSpaces = useMemo(() => {
+    const query = spaceQuery.trim().toLowerCase();
+    if (!query) return availableSpaces;
+    return availableSpaces.filter((s) => s.location.code.toLowerCase().includes(query));
+  }, [availableSpaces, spaceQuery]);
+  const shownSpaces = filteredSpaces.slice(0, SPACE_LIMIT);
+
+  const computeValidation = useCallback(
+    (location: WarehouseLocation | null): ValidationResult | null => {
+      if (!location || !settings || !ready) return null;
+      return validateMove({
+        settings,
+        destination: location,
+        destinationInventory: inventory.filter((r) => r.locationId === location.id),
+        destinationPalletCount: pallets.filter((p) => p.currentLocationId === location.id).length,
+        item,
+        quantity,
+        added,
+        destinationHoldsStock: locationHoldsStock(location, purposeById),
+        destinationCounted: !outsideIds.has(location.id),
+      });
+    },
+    [settings, ready, inventory, pallets, item, quantity, added, purposeById, outsideIds],
+  );
+
+  const selectLocation = useCallback(
+    (locationId: string | null) => {
+      const location = locationId
+        ? warehouseLocations.find((l) => l.id === locationId) ?? null
+        : null;
+      onChange({ location, validation: computeValidation(location) });
+    },
+    [warehouseLocations, computeValidation, onChange],
+  );
+
+  /** Scanning/typing a bin code jumps straight to it (even if invalid, so the
+   * validation panel can explain why). */
+  const selectSpaceByCode = useCallback(
+    (code: string) => {
+      const key = code.trim().toLowerCase();
+      if (!key) return;
+      const location = warehouseLocations.find((l) => l.code.toLowerCase() === key);
+      if (location) {
+        selectLocation(location.id);
+        setSpaceQuery('');
+      } else {
+        toast.error('No space matched that code.');
+      }
+    },
+    [warehouseLocations, selectLocation],
+  );
+
+  const selectedLocation = selectedLocationId
+    ? warehouseLocations.find((l) => l.id === selectedLocationId) ?? null
+    : null;
+  const validation = useMemo(
+    () => computeValidation(selectedLocation),
+    [computeValidation, selectedLocation],
+  );
+
+  if (!ready) {
+    return <p className="text-sm text-muted-foreground">Nothing to put away.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Pick an empty space by section — no scanning needed. */}
+      <div className="space-y-1.5">
+        <Label htmlFor="bst-putaway-empty">
+          Pick an empty location
+          <span className="ml-1 text-xs font-normal text-muted-foreground">({totalEmpty} empty)</span>
+        </Label>
+        <NativeSelect
+          id="bst-putaway-empty"
+          value={selectedLocationId ?? ''}
+          onChange={(event) => selectLocation(event.target.value || null)}
+        >
+          <option value="">Select an empty location…</option>
+          {emptyBySection.map((section) => (
+            <optgroup key={section.key} label={section.label}>
+              {section.locations.map((location) => (
+                <option key={location.id} value={location.id}>
+                  {location.code}
+                  {recommendedIds.has(location.id) ? ' ★' : ''}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </NativeSelect>
+        {totalEmpty === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            No empty locations for this item — the spaces below are partly filled.
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex gap-2">
+        <Input
+          value={spaceQuery}
+          placeholder="Search spaces, or scan a bin"
+          onChange={(event) => setSpaceQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && spaceQuery.trim()) selectSpaceByCode(spaceQuery);
+          }}
+        />
+        <WmsScanButton label="Scan" onScan={selectSpaceByCode} />
+      </div>
+
+      {availableSpaces.length === 0 ? (
+        <p className="rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+          No available spaces — every block is full, restricted for this item, or outside a numbered
+          area.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Sparkles className="h-3.5 w-3.5" />
+            {filteredSpaces.length} available space{filteredSpaces.length === 1 ? '' : 's'} · ★ =
+            recommended
+          </p>
+          <div className="grid max-h-56 grid-cols-2 gap-2 overflow-auto rounded-md border p-2 sm:grid-cols-3">
+            {shownSpaces.map((space) => {
+              const selected = selectedLocationId === space.location.id;
+              const recommended = recommendedIds.has(space.location.id);
+              return (
+                <button
+                  key={space.location.id}
+                  type="button"
+                  onClick={() => selectLocation(space.location.id)}
+                  className={`flex flex-col items-start rounded-md border px-2.5 py-1.5 text-left transition ${
+                    selected ? 'border-primary ring-2 ring-primary/30' : 'hover:bg-muted/50'
+                  }`}
+                >
+                  <span className="flex items-center gap-1 font-mono text-sm">
+                    {recommended ? <span className="text-emerald-600">★</span> : null}
+                    {space.location.code}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {Math.round(space.occupancyPct)}% full
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          {filteredSpaces.length > shownSpaces.length ? (
+            <p className="text-xs text-muted-foreground">
+              Showing the top {shownSpaces.length} of {filteredSpaces.length} — search to narrow down.
+            </p>
+          ) : null}
+        </div>
+      )}
+
+      {validation ? (
+        <div className="space-y-2">
+          {validation.errors.map((issue) => (
+            <p
+              key={issue.code}
+              className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              {issue.message}
+            </p>
+          ))}
+          {validation.warnings.map((issue) => (
+            <p
+              key={issue.code}
+              className="rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400"
+            >
+              {issue.message}
+            </p>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/modules/wms/pages/WmsMapPage.tsx
+++ b/src/modules/wms/pages/WmsMapPage.tsx
@@ -140,6 +140,24 @@ export default function WmsMapPage() {
     return map;
   }, [inventory]);
 
+  // A short, multi-line summary of what a location holds — used for the hover
+  // tooltip so the operator sees the item/qty/lot without opening the panel.
+  const stockSummary = useMemo(() => {
+    return (locationId: string): string => {
+      const records = inventoryByLocation.get(locationId) ?? [];
+      if (records.length === 0) return 'Empty';
+      const lines = records.slice(0, 4).map((record) => {
+        const name = record.itemName || record.itemCode || 'Item';
+        const bits = [`${record.quantity} ${record.uom}`];
+        if (record.boxCount) bits.push(`${record.boxCount} box${record.boxCount === 1 ? '' : 'es'}`);
+        if (record.lotNumber) bits.push(`lot ${record.lotNumber}`);
+        return `• ${name} (${bits.join(' · ')})`;
+      });
+      if (records.length > 4) lines.push(`• +${records.length - 4} more`);
+      return lines.join('\n');
+    };
+  }, [inventoryByLocation]);
+
   const safeLevel = warehouse ? Math.min(level, Math.max(0, warehouse.levels - 1)) : 0;
   const levelLocations = useMemo(
     () => locations.filter((location) => location.level === safeLevel),
@@ -309,7 +327,7 @@ export default function WmsMapPage() {
           tooltip:
             purpose && !purpose.holdsStock
               ? `${location.code} · ${purpose.name}`
-              : `${location.code} · ${DISPLAY_STATUS_META[occ?.status ?? 'EMPTY'].label} · ${Math.round(occ?.occupancyPct ?? 0)}%${purpose ? ` · ${purpose.name}` : ''}`,
+              : `${location.code} · ${DISPLAY_STATUS_META[occ?.status ?? 'EMPTY'].label} · ${Math.round(occ?.occupancyPct ?? 0)}%${purpose ? ` · ${purpose.name}` : ''}\n${stockSummary(location.id)}`,
         };
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/modules/wms/pages/WmsReceivePage.tsx
+++ b/src/modules/wms/pages/WmsReceivePage.tsx
@@ -1,17 +1,18 @@
 /**
- * Receiving & putaway flow (Step 7).
+ * Receiving & putaway flow — pallet-first.
  *
- * The operator scans an item (or new pallet plate) to identify the material,
- * records box count / units-per-box / lot / expiry, then puts it away. In
- * directed or hybrid mode the system suggests the best legal block (via the
- * putaway engine, which reuses Step 6 validation); in manual mode the operator
- * scans a destination. On confirm the store creates the pallet + inventory,
- * writes a PUTAWAY movement, and the map updates.
+ * The operator scans a PALLET plate; the system resolves the pallet from the
+ * barcode module (item, quantity, boxes, lot, warehouse) and shows it as
+ * read-only text — nothing is typed. Then they scan or pick the destination bin
+ * and place it. On confirm the pallet is put away via the external-pallet bridge
+ * (`syncExternalPalletPlacement`): a WMS Pallet + Inventory + PUTAWAY movement,
+ * keyed by the plate.
  */
-import { PackagePlus, ScanLine, Sparkles } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { Loader2, PackagePlus, ScanLine } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
+import { barcodeApi } from '@/modules/barcode/api';
 import {
   Button,
   Card,
@@ -23,250 +24,162 @@ import {
   NativeSelect,
 } from '@/shared/components/ui';
 
+import { PutawayBinPicker, type PutawaySelection } from '../components/PutawayBinPicker';
 import { WmsDisabledNotice } from '../components/WmsDisabledNotice';
 import type { WmsLabelData } from '../components/WmsPrintLabel';
 import { WmsPrintLabelButton } from '../components/WmsPrintLabelButton';
 import { WmsScanButton } from '../components/WmsScanButton';
-import type { MoveItem, PutawaySuggestion, ValidationResult } from '../services';
-import {
-  buildOccupancyIndex,
-  countEmptyLocations,
-  groupEmptyLocationsBySection,
-  locationHoldsStock,
-  outsideLocationIds,
-  suggestPutaway,
-  validateMove,
-} from '../services';
-import { useWarehouses, useWmsCollection, useWmsEnabled, useWmsSettings, wmsStore } from '../store';
+import type { MoveItem } from '../services';
+import { useWarehouses, useWmsCollection, useWmsEnabled } from '../store';
+import { wmsStore } from '../store';
 import type { MaterialWarehouseProfile } from '../types';
 import { notifyFail, notifyOk } from '../utils';
 
+/** A pallet resolved from a scanned plate (barcode-module lookup). */
+interface ResolvedPallet {
+  palletId: string;
+  itemCode: string;
+  itemName: string;
+  batchNumber: string;
+  boxCount: number;
+  totalQty: number;
+  uom: string;
+  warehouseCode: string;
+}
+
+function sameCode(a?: string | null, b?: string | null): boolean {
+  return (a ?? '').trim().toLowerCase() === (b ?? '').trim().toLowerCase();
+}
+
+/** Extract the fields we need from the untyped lookup `entity_data`. */
+function toResolvedPallet(data: Record<string, unknown>): ResolvedPallet {
+  const str = (v: unknown) => (typeof v === 'string' ? v : v == null ? '' : String(v));
+  const num = (v: unknown) => (typeof v === 'number' ? v : Number(v) || 0);
+  return {
+    palletId: str(data.pallet_id),
+    itemCode: str(data.item_code),
+    itemName: str(data.item_name),
+    batchNumber: str(data.batch_number),
+    boxCount: num(data.box_count),
+    totalQty: num(data.total_qty),
+    uom: str(data.uom) || 'EA',
+    warehouseCode: str(data.current_warehouse),
+  };
+}
+
 export default function WmsReceivePage() {
   const enabled = useWmsEnabled();
-  const { settings } = useWmsSettings();
   const { warehouses } = useWarehouses();
-  const { data: locations } = useWmsCollection('locations');
-  const { data: purposes } = useWmsCollection('cellPurposes');
-  const { data: inventory } = useWmsCollection('inventory');
-  const { data: pallets } = useWmsCollection('pallets');
   const { data: materials } = useWmsCollection('materials');
 
-  const [warehouseId, setWarehouseId] = useState<string>('');
-  const [scanQuery, setScanQuery] = useState('');
-  const [itemCode, setItemCode] = useState('');
-  const [itemName, setItemName] = useState('');
-  const [lotNumber, setLotNumber] = useState('');
-  const [expiry, setExpiry] = useState('');
-  const [licensePlate, setLicensePlate] = useState('');
-  const [boxCount, setBoxCount] = useState(1);
-  const [unitsPerBox, setUnitsPerBox] = useState<number | ''>('');
-  const [uom, setUom] = useState('EA');
-  const [spaceQuery, setSpaceQuery] = useState('');
-  const [destLocationId, setDestLocationId] = useState<string | null>(null);
+  const [plateInput, setPlateInput] = useState('');
+  const [pallet, setPallet] = useState<ResolvedPallet | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const [warehouseOverride, setWarehouseOverride] = useState<string | null>(null);
+  const [selection, setSelection] = useState<PutawaySelection>({ location: null, validation: null });
   const [busy, setBusy] = useState(false);
-  // The label for the most recently received pallet, so it can be printed.
   const [lastPalletLabel, setLastPalletLabel] = useState<WmsLabelData | null>(null);
 
-  const activeWarehouseId = warehouseId || warehouses[0]?.id || '';
-
-  const warehouseLocations = useMemo(
-    () => locations.filter((location) => location.warehouseId === activeWarehouseId),
-    [locations, activeWarehouseId],
-  );
-  const activeWarehouse = useMemo(
-    () => warehouses.find((wh) => wh.id === activeWarehouseId) ?? null,
-    [warehouses, activeWarehouseId],
-  );
-  const outsideIds = useMemo(
-    () => (activeWarehouse ? outsideLocationIds(activeWarehouse, warehouseLocations) : new Set<string>()),
-    [activeWarehouse, warehouseLocations],
-  );
-  const purposeById = useMemo(
-    () => new Map(purposes.map((purpose) => [purpose.id, purpose])),
-    [purposes],
-  );
   const materialByItem = useMemo(() => {
     const map = new Map<string, MaterialWarehouseProfile>();
     for (const material of materials) map.set(material.itemCode, material);
     return map;
   }, [materials]);
+  const profile = pallet ? materialByItem.get(pallet.itemCode) : undefined;
+  const itemType = profile?.materialType ?? '';
 
-  const quantity = boxCount * (typeof unitsPerBox === 'number' && unitsPerBox > 0 ? unitsPerBox : 1);
-  const profile = materialByItem.get(itemCode);
+  // Total units to place — fall back to the box count when the pallet carries no
+  // unit quantity, so the putaway engine still has a positive number to rank by.
+  const quantity = pallet ? (pallet.totalQty > 0 ? pallet.totalQty : pallet.boxCount) : 0;
 
-  // A scanned item resolved against the catalog needs no manual identity entry —
-  // the master already holds its name, UoM, units/box and what it tracks. Only
-  // ask for the per-receipt fields the item is actually configured to track.
-  const recognized = Boolean(profile);
-  const showLot = recognized ? Boolean(profile?.trackLot) : true;
-  const showExpiry = recognized ? Boolean(profile?.trackExpiry) : true;
+  // Default the warehouse to the OWN warehouse matching the pallet's current
+  // warehouse code; the operator can override when there is more than one.
+  const matchedWarehouseId = useMemo(() => {
+    if (!pallet?.warehouseCode) return '';
+    const match = warehouses.find(
+      (wh) => (wh.type ?? 'OWN') === 'OWN' && sameCode(wh.sapWarehouseCode, pallet.warehouseCode),
+    );
+    return match?.id ?? '';
+  }, [warehouses, pallet?.warehouseCode]);
+  const warehouseId = warehouseOverride || matchedWarehouseId || warehouses[0]?.id || '';
 
   const item: MoveItem = useMemo(
     () => ({
-      itemCode,
+      itemCode: pallet?.itemCode ?? '',
       materialType: profile?.materialType ?? '',
       temperatureClass: profile?.temperatureClass ?? null,
       hazmatClass: profile?.hazmatClass ?? '',
-      lotNumber,
+      lotNumber: pallet?.batchNumber ?? '',
       serialNumber: '',
-      expiryDate: expiry || null,
+      expiryDate: null,
     }),
-    [itemCode, profile, lotNumber, expiry],
+    [pallet, profile],
   );
   const added = useMemo(
     () => ({
-      pallets: licensePlate.trim() ? 1 : 0,
+      pallets: 1,
       units: quantity,
       weight: profile?.weightPerUnit ? profile.weightPerUnit * quantity : 0,
       volume: profile?.volumePerUnit ? profile.volumePerUnit * quantity : 0,
     }),
-    [licensePlate, quantity, profile],
+    [quantity, profile],
   );
 
-  const ready = itemCode.trim().length > 0 && quantity > 0;
-
-  // Every legal destination for this item, ranked best-first. This is the pool of
-  // "available spaces" the operator picks from — the putaway engine already vets
-  // capacity, material rules, temperature, hazmat and area membership.
-  const availableSpaces: PutawaySuggestion[] = useMemo(() => {
-    if (!ready || !settings) return [];
-    return suggestPutaway({
-      settings,
-      item,
-      quantity,
-      added,
-      locations: warehouseLocations.filter((l) => !outsideIds.has(l.id)),
-      inventory,
-      pallets,
-      purposesById: purposeById,
-      limit: warehouseLocations.length,
-    });
-  }, [ready, settings, item, quantity, added, warehouseLocations, inventory, pallets, purposeById, outsideIds]);
-
-  // The engine's top picks, highlighted with a ★ in the list.
-  const recommendedIds = useMemo(
-    () => new Set(availableSpaces.slice(0, 3).map((s) => s.location.id)),
-    [availableSpaces],
-  );
-
-  const occupancy = useMemo(
-    () => buildOccupancyIndex(warehouseLocations, inventory, pallets, purposeById),
-    [warehouseLocations, inventory, pallets, purposeById],
-  );
-
-  // Empty spaces only, grouped by section — the dropdown the operator picks from.
-  // Restricted to spaces the putaway engine already deemed legal for this item.
-  const emptyBySection = useMemo(() => {
-    const legalIds = new Set(availableSpaces.map((space) => space.location.id));
-    return groupEmptyLocationsBySection({
-      locations: warehouseLocations.filter((location) => legalIds.has(location.id)),
-      warehouses,
-      occupancy,
-      purposesById: purposeById,
-    });
-  }, [availableSpaces, warehouseLocations, warehouses, occupancy, purposeById]);
-
-  const totalEmpty = useMemo(() => countEmptyLocations(emptyBySection), [emptyBySection]);
-
-  const SPACE_LIMIT = 90;
-  const filteredSpaces = useMemo(() => {
-    const query = spaceQuery.trim().toLowerCase();
-    if (!query) return availableSpaces;
-    return availableSpaces.filter((s) => s.location.code.toLowerCase().includes(query));
-  }, [availableSpaces, spaceQuery]);
-  const shownSpaces = filteredSpaces.slice(0, SPACE_LIMIT);
-
-  const destLocation = destLocationId
-    ? warehouseLocations.find((location) => location.id === destLocationId) ?? null
-    : null;
-
-  const validation: ValidationResult | null = useMemo(() => {
-    if (!destLocation || !settings || !ready) return null;
-    return validateMove({
-      settings,
-      destination: destLocation,
-      destinationInventory: inventory.filter((r) => r.locationId === destLocation.id),
-      destinationPalletCount: pallets.filter((p) => p.currentLocationId === destLocation.id).length,
-      item,
-      quantity,
-      added,
-      destinationHoldsStock: locationHoldsStock(destLocation, purposeById),
-      destinationCounted: !outsideIds.has(destLocation.id),
-    });
-  }, [destLocation, settings, ready, inventory, pallets, item, quantity, added, purposeById, outsideIds]);
-
-  function applyScan(override?: string) {
-    const query = (override ?? scanQuery).trim();
+  const resolvePallet = useCallback(async (raw: string) => {
+    const query = raw.trim();
     if (!query) return;
-    const existingPallet = pallets.find((p) => p.licensePlate.toLowerCase() === query.toLowerCase());
-    if (existingPallet) {
-      setLicensePlate(existingPallet.licensePlate);
-      setItemCode(existingPallet.itemCode);
-      setItemName(existingPallet.itemName);
-      return;
+    setResolving(true);
+    try {
+      const result = await barcodeApi.lookupBarcode(query);
+      if (result.entity_type !== 'PALLET' || !result.entity_data) {
+        toast.error(
+          result.entity_type === 'BOX'
+            ? 'That is a box barcode — scan the pallet.'
+            : 'No pallet found for that barcode.',
+        );
+        return;
+      }
+      setPallet(toResolvedPallet(result.entity_data));
+      setSelection({ location: null, validation: null });
+      setWarehouseOverride(null);
+      setPlateInput('');
+    } catch (error) {
+      notifyFail(error instanceof Error ? error.message : 'Could not look up that pallet.');
+    } finally {
+      setResolving(false);
     }
-    setItemCode(query);
-    const found = materialByItem.get(query);
-    if (found) {
-      setItemName(found.itemName);
-      if (found.unitsPerBox) setUnitsPerBox(found.unitsPerBox);
-      if (found.defaultUom) setUom(found.defaultUom);
-    }
+  }, []);
+
+  function clearPallet() {
+    setPallet(null);
+    setSelection({ location: null, validation: null });
+    setWarehouseOverride(null);
+    setPlateInput('');
   }
 
-  /** Scanning a bin code jumps straight to it (selecting even if it's invalid,
-   * so the validation panel can explain why). */
-  function selectSpaceByCode(code: string) {
-    const key = code.trim().toLowerCase();
-    if (!key) return;
-    const location = warehouseLocations.find((l) => l.code.toLowerCase() === key);
-    if (location) {
-      setDestLocationId(location.id);
-      setSpaceQuery('');
-    } else {
-      toast.error('No space matched that code.');
-    }
-  }
-
-  function reset() {
-    setScanQuery('');
-    setItemCode('');
-    setItemName('');
-    setLotNumber('');
-    setExpiry('');
-    setLicensePlate('');
-    setBoxCount(1);
-    setUnitsPerBox('');
-    setSpaceQuery('');
-    setDestLocationId(null);
-  }
-
-  async function confirm() {
-    if (!destLocationId || !validation?.ok) return;
+  async function place() {
+    if (!pallet || !selection.location || !selection.validation?.ok) return;
     setBusy(true);
     try {
-      await wmsStore.receiveStock({
-        destLocationId,
-        itemCode: itemCode.trim(),
-        itemName: itemName.trim(),
-        lotNumber: lotNumber.trim(),
-        expiryDate: expiry || null,
-        uom,
-        quantity,
-        boxCount,
-        unitsPerBox: typeof unitsPerBox === 'number' ? unitsPerBox : null,
-        weight: added.weight || null,
-        volume: added.volume || null,
-        licensePlate: licensePlate.trim() || undefined,
+      await wmsStore.syncExternalPalletPlacement({
+        licensePlate: pallet.palletId,
+        toLocationId: selection.location.id,
+        itemCode: pallet.itemCode,
+        itemName: pallet.itemName,
+        lotNumber: pallet.batchNumber,
+        boxCount: pallet.boxCount,
+        totalUnits: quantity,
+        uom: pallet.uom,
+        note: 'Warehouse Ops receive',
       });
-      notifyOk(`Received ${quantity} ${uom} into ${destLocation?.code}.`);
-      const plate = licensePlate.trim();
-      setLastPalletLabel(
-        plate
-          ? { code: plate, title: plate, heading: 'PALLET', subtitle: itemName.trim() || itemCode.trim() }
-          : null,
-      );
-      reset();
+      notifyOk(`Pallet ${pallet.palletId} placed in ${selection.location.code}.`);
+      setLastPalletLabel({
+        code: pallet.palletId,
+        title: pallet.palletId,
+        heading: 'PALLET',
+        subtitle: pallet.itemName || pallet.itemCode,
+      });
+      clearPallet();
     } catch (error) {
       notifyFail(error instanceof Error ? error.message : 'Receive failed.');
     } finally {
@@ -292,283 +205,132 @@ export default function WmsReceivePage() {
 
   return (
     <div className="mx-auto max-w-3xl space-y-5 p-4 md:p-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Receive &amp; Put Away</h1>
-          <p className="text-sm text-muted-foreground">
-            Scan stock onto a pallet, then put it in the right block.
-          </p>
-        </div>
-        {warehouses.length > 1 ? (
-          <NativeSelect
-            className="w-full sm:w-52"
-            value={activeWarehouseId}
-            onChange={(event) => {
-              setWarehouseId(event.target.value);
-              setDestLocationId(null);
-              setSpaceQuery('');
-            }}
-          >
-            {warehouses.map((wh) => (
-              <option key={wh.id} value={wh.id}>
-                {wh.name}
-              </option>
-            ))}
-          </NativeSelect>
-        ) : null}
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Receive &amp; Put Away</h1>
+        <p className="text-sm text-muted-foreground">
+          Scan a pallet, then scan where it goes — the rest is filled in for you.
+        </p>
       </div>
 
-      {/* 1. Item / pallet */}
+      {/* 1. Pallet */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">1 · What are you receiving?</CardTitle>
+          <CardTitle className="text-base">1 · Scan the pallet</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          <div className="flex gap-2">
-            <Input
-              autoFocus
-              value={scanQuery}
-              placeholder="Scan item code or pallet plate"
-              onChange={(event) => setScanQuery(event.target.value)}
-              onKeyDown={(event) => event.key === 'Enter' && applyScan()}
-            />
-            <WmsScanButton
-              label="Scan"
-              onScan={(code) => {
-                setScanQuery(code);
-                applyScan(code);
-              }}
-            />
-            <Button variant="outline" onClick={() => applyScan()}>
-              <ScanLine className="mr-2 h-4 w-4" /> Identify
-            </Button>
-          </div>
-
-          {itemCode.trim() ? (
-            recognized ? (
-              /* Scan matched the catalog — show what we know, don't re-ask for it. */
-              <div className="flex items-baseline justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2.5">
+          {!pallet ? (
+            <div className="flex gap-2">
+              <Input
+                autoFocus
+                value={plateInput}
+                placeholder="Scan or type a pallet plate"
+                disabled={resolving}
+                onChange={(event) => setPlateInput(event.target.value)}
+                onKeyDown={(event) => event.key === 'Enter' && void resolvePallet(plateInput)}
+              />
+              <WmsScanButton label="Scan" onScan={(code) => void resolvePallet(code)} />
+              <Button
+                variant="outline"
+                disabled={resolving || !plateInput.trim()}
+                onClick={() => void resolvePallet(plateInput)}
+              >
+                {resolving ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <ScanLine className="mr-2 h-4 w-4" />
+                )}
+                Find
+              </Button>
+            </div>
+          ) : (
+            <div className="rounded-md border bg-muted/30 px-3 py-3">
+              <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-medium">{itemName || itemCode}</p>
-                  <p className="text-xs text-muted-foreground">
-                    <span className="font-mono">{itemCode}</span> · {uom}
-                    {typeof unitsPerBox === 'number' && unitsPerBox > 0 ? ` · ${unitsPerBox}/box` : ''}
-                  </p>
+                  <p className="truncate text-sm font-semibold">{pallet.itemName || pallet.itemCode}</p>
+                  <p className="font-mono text-xs text-muted-foreground">{pallet.palletId}</p>
                 </div>
                 <button
                   type="button"
-                  onClick={reset}
+                  onClick={clearPallet}
                   className="shrink-0 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
                 >
-                  Change
+                  Scan another
                 </button>
               </div>
-            ) : (
-              /* Code isn't in the catalog — fall back to manual identity entry. */
-              <div className="space-y-3">
-                <p className="rounded-md bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
-                  Not in the item catalog — confirm the details below.
-                </p>
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  <Field label="Item code">
-                    <Input value={itemCode} onChange={(event) => setItemCode(event.target.value)} />
-                  </Field>
-                  <Field label="Item name">
-                    <Input value={itemName} onChange={(event) => setItemName(event.target.value)} />
-                  </Field>
-                  <Field label="UoM">
-                    <Input value={uom} onChange={(event) => setUom(event.target.value)} />
-                  </Field>
-                  <Field label="Units per box">
-                    <Input
-                      type="number"
-                      min={1}
-                      value={unitsPerBox}
-                      placeholder="1"
-                      onChange={(event) =>
-                        setUnitsPerBox(event.target.value === '' ? '' : Math.max(1, Number(event.target.value) || 1))
-                      }
-                    />
-                  </Field>
-                </div>
-              </div>
-            )
-          ) : null}
-
-          {itemCode.trim() ? (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              <Field label="Boxes">
-                <Input
-                  type="number"
-                  min={1}
-                  value={boxCount}
-                  onChange={(event) => setBoxCount(Math.max(1, Number(event.target.value) || 1))}
-                />
-              </Field>
-              <Field label="Pallet plate (optional)">
-                <div className="flex gap-2">
-                  <Input
-                    value={licensePlate}
-                    placeholder="Leave blank for loose stock"
-                    onChange={(event) => setLicensePlate(event.target.value)}
-                  />
-                  <WmsScanButton label="Scan" onScan={setLicensePlate} />
-                </div>
-              </Field>
-              {showLot ? (
-                <Field label="Lot">
-                  <Input value={lotNumber} onChange={(event) => setLotNumber(event.target.value)} />
-                </Field>
-              ) : null}
-              {showExpiry ? (
-                <Field label="Expiry">
-                  <Input type="date" value={expiry} onChange={(event) => setExpiry(event.target.value)} />
-                </Field>
-              ) : null}
+              <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
+                <Info label="Item code" value={pallet.itemCode} mono />
+                <Info label="Item type" value={itemType || '—'} />
+                <Info label="Boxes" value={String(pallet.boxCount)} />
+                <Info label="Quantity" value={`${quantity} ${pallet.uom}`} />
+                {pallet.batchNumber ? <Info label="Lot" value={pallet.batchNumber} /> : null}
+                {pallet.warehouseCode ? <Info label="From" value={pallet.warehouseCode} /> : null}
+              </dl>
             </div>
-          ) : null}
-
-          {ready ? (
-            <p className="text-sm text-muted-foreground">
-              Total: <span className="font-medium text-foreground">{quantity} {uom}</span>
-              {licensePlate.trim() ? ' · 1 pallet' : ''}
-            </p>
-          ) : null}
+          )}
         </CardContent>
       </Card>
 
-      {/* 2. Putaway */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">2 · Choose a space</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {!ready ? (
-            <p className="text-sm text-muted-foreground">
-              Identify the item above to see the spaces it can go into.
-            </p>
-          ) : (
-            <>
-              {/* Pick an empty space by section — no scanning needed. */}
+      {/* 2. Location */}
+      {pallet ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">2 · Scan the location</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {warehouses.length > 1 ? (
               <div className="space-y-1.5">
-                <Label htmlFor="empty-space-select">
-                  Pick an empty location
-                  <span className="ml-1 text-xs font-normal text-muted-foreground">
-                    ({totalEmpty} empty)
-                  </span>
-                </Label>
+                <Label htmlFor="receive-warehouse">Warehouse</Label>
                 <NativeSelect
-                  id="empty-space-select"
-                  value={destLocationId ?? ''}
-                  onChange={(event) => setDestLocationId(event.target.value || null)}
+                  id="receive-warehouse"
+                  value={warehouseId}
+                  onChange={(event) => {
+                    setWarehouseOverride(event.target.value);
+                    setSelection({ location: null, validation: null });
+                  }}
                 >
-                  <option value="">Select an empty location…</option>
-                  {emptyBySection.map((section) => (
-                    <optgroup key={section.key} label={section.label}>
-                      {section.locations.map((location) => (
-                        <option key={location.id} value={location.id}>
-                          {location.code}
-                          {recommendedIds.has(location.id) ? ' ★' : ''}
-                        </option>
-                      ))}
-                    </optgroup>
+                  {warehouses.map((wh) => (
+                    <option key={wh.id} value={wh.id}>
+                      {wh.name}
+                    </option>
                   ))}
                 </NativeSelect>
-                {totalEmpty === 0 ? (
-                  <p className="text-xs text-muted-foreground">
-                    No empty locations for this item — the spaces below are partly filled.
-                  </p>
-                ) : null}
               </div>
+            ) : null}
 
-              <div className="flex gap-2">
-                <Input
-                  value={spaceQuery}
-                  placeholder="Search spaces, or scan a bin"
-                  onChange={(event) => setSpaceQuery(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter' && spaceQuery.trim()) selectSpaceByCode(spaceQuery);
-                  }}
-                />
-                <WmsScanButton label="Scan" onScan={selectSpaceByCode} />
-              </div>
+            {warehouseId ? (
+              <PutawayBinPicker
+                warehouseId={warehouseId}
+                item={item}
+                quantity={quantity}
+                added={added}
+                selectedLocationId={selection.location?.id ?? null}
+                onChange={setSelection}
+              />
+            ) : null}
 
-              {availableSpaces.length === 0 ? (
-                <p className="rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
-                  No available spaces — every block is full, restricted for this item, or outside a
-                  numbered area.
-                </p>
+            <Button
+              className="w-full"
+              disabled={busy || !selection.validation?.ok}
+              onClick={() => void place()}
+            >
+              {busy ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               ) : (
-                <div className="space-y-2">
-                  <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                    <Sparkles className="h-3.5 w-3.5" />
-                    {filteredSpaces.length} available space{filteredSpaces.length === 1 ? '' : 's'} ·
-                    ★ = recommended
-                  </p>
-                  <div className="grid max-h-64 grid-cols-2 gap-2 overflow-auto rounded-md border p-2 sm:grid-cols-3">
-                    {shownSpaces.map((space) => {
-                      const selected = destLocationId === space.location.id;
-                      const recommended = recommendedIds.has(space.location.id);
-                      return (
-                        <button
-                          key={space.location.id}
-                          type="button"
-                          onClick={() => setDestLocationId(space.location.id)}
-                          className={`flex flex-col items-start rounded-md border px-2.5 py-1.5 text-left transition ${
-                            selected ? 'border-primary ring-2 ring-primary/30' : 'hover:bg-muted/50'
-                          }`}
-                        >
-                          <span className="flex items-center gap-1 font-mono text-sm">
-                            {recommended ? <span className="text-emerald-600">★</span> : null}
-                            {space.location.code}
-                          </span>
-                          <span className="text-xs text-muted-foreground">
-                            {Math.round(space.occupancyPct)}% full
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                  {filteredSpaces.length > shownSpaces.length ? (
-                    <p className="text-xs text-muted-foreground">
-                      Showing the top {shownSpaces.length} of {filteredSpaces.length} — search to
-                      narrow down.
-                    </p>
-                  ) : null}
-                </div>
+                <PackagePlus className="mr-2 h-4 w-4" />
               )}
-            </>
-          )}
+              Place in {selection.location?.code ?? 'location'}
+            </Button>
+          </CardContent>
+        </Card>
+      ) : null}
 
-          {validation ? (
-            <div className="space-y-2">
-              {validation.errors.map((issue) => (
-                <p key={issue.code} className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                  {issue.message}
-                </p>
-              ))}
-              {validation.warnings.map((issue) => (
-                <p key={issue.code} className="rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
-                  {issue.message}
-                </p>
-              ))}
-            </div>
-          ) : null}
-
-          <Button className="w-full" disabled={busy || !ready || !validation?.ok} onClick={() => void confirm()}>
-            <PackagePlus className="mr-2 h-4 w-4" />
-            Receive into {destLocation?.code ?? 'location'}
-          </Button>
-        </CardContent>
-      </Card>
-
-      {/* Print the just-received pallet's QR label (TSC DA310, 100x40mm). */}
+      {/* Print the just-placed pallet's QR label (TSC DA310, 100x40mm). */}
       {lastPalletLabel ? (
         <Card className="border-emerald-400 bg-emerald-50 dark:bg-emerald-950/30">
           <CardContent className="flex flex-wrap items-center justify-between gap-3 py-3">
             <div className="text-sm">
-              Pallet <span className="font-mono font-semibold">{lastPalletLabel.title}</span> received.
-              Print its QR label to put on the pallet.
+              Pallet <span className="font-mono font-semibold">{lastPalletLabel.title}</span> placed.
+              Print its QR label if the pallet needs one.
             </div>
             <div className="flex items-center gap-2">
               <WmsPrintLabelButton labels={[lastPalletLabel]} label="Print pallet label" />
@@ -583,11 +345,11 @@ export default function WmsReceivePage() {
   );
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function Info({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
-    <div className="space-y-1.5">
-      <Label className="text-xs text-muted-foreground">{label}</Label>
-      {children}
+    <div className="space-y-0.5">
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className={mono ? 'font-mono' : ''}>{value}</dd>
     </div>
   );
 }

--- a/src/modules/wms/pages/WmsReceivePage.tsx
+++ b/src/modules/wms/pages/WmsReceivePage.tsx
@@ -47,10 +47,6 @@ interface ResolvedPallet {
   warehouseCode: string;
 }
 
-function sameCode(a?: string | null, b?: string | null): boolean {
-  return (a ?? '').trim().toLowerCase() === (b ?? '').trim().toLowerCase();
-}
-
 /** Extract the fields we need from the untyped lookup `entity_data`. */
 function toResolvedPallet(data: Record<string, unknown>): ResolvedPallet {
   const str = (v: unknown) => (typeof v === 'string' ? v : v == null ? '' : String(v));
@@ -98,16 +94,11 @@ export default function WmsReceivePage() {
   // unit quantity, so the putaway engine still has a positive number to rank by.
   const quantity = pallet ? (pallet.totalQty > 0 ? pallet.totalQty : pallet.boxCount) : 0;
 
-  // Default the warehouse to the OWN warehouse matching the pallet's current
-  // warehouse code; the operator can override when there is more than one.
-  const matchedWarehouseId = useMemo(() => {
-    if (!pallet?.warehouseCode) return '';
-    const match = warehouses.find(
-      (wh) => (wh.type ?? 'OWN') === 'OWN' && sameCode(wh.sapWarehouseCode, pallet.warehouseCode),
-    );
-    return match?.id ?? '';
-  }, [warehouses, pallet?.warehouseCode]);
-  const warehouseId = warehouseOverride || matchedWarehouseId || warehouses[0]?.id || '';
+  // The operator chooses which warehouse to receive INTO. We deliberately do NOT
+  // infer it from the pallet's current (source) warehouse: a pallet finished on
+  // the production floor is received into a separate storage warehouse, so the
+  // source code is shown only as "From" info, never used to pick the destination.
+  const warehouseId = warehouseOverride || warehouses[0]?.id || '';
 
   const item: MoveItem = useMemo(
     () => ({

--- a/src/modules/wms/pages/WmsReceivePage.tsx
+++ b/src/modules/wms/pages/WmsReceivePage.tsx
@@ -9,7 +9,7 @@
  * keyed by the plate.
  */
 import { Loader2, PackagePlus, ScanLine } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { barcodeApi } from '@/modules/barcode/api';
@@ -74,7 +74,11 @@ export default function WmsReceivePage() {
 
   const [plateInput, setPlateInput] = useState('');
   const [pallet, setPallet] = useState<ResolvedPallet | null>(null);
+  const [itemGroup, setItemGroup] = useState<string | null>(null);
   const [resolving, setResolving] = useState(false);
+  // The plate whose item group is currently being fetched — guards against a
+  // slow lookup landing after the operator has scanned a different pallet.
+  const requestedPlateRef = useRef('');
   const [warehouseOverride, setWarehouseOverride] = useState<string | null>(null);
   const [selection, setSelection] = useState<PutawaySelection>({ location: null, validation: null });
   const [busy, setBusy] = useState(false);
@@ -86,7 +90,9 @@ export default function WmsReceivePage() {
     return map;
   }, [materials]);
   const profile = pallet ? materialByItem.get(pallet.itemCode) : undefined;
-  const itemType = profile?.materialType ?? '';
+  // "Item type" = the item's SAP item group (looked up on scan); falls back to
+  // the WMS material profile's type when the group isn't available.
+  const itemType = itemGroup ?? profile?.materialType ?? '';
 
   // Total units to place — fall back to the box count when the pallet carries no
   // unit quantity, so the putaway engine still has a positive number to rank by.
@@ -139,10 +145,23 @@ export default function WmsReceivePage() {
         );
         return;
       }
-      setPallet(toResolvedPallet(result.entity_data));
+      const resolved = toResolvedPallet(result.entity_data);
+      requestedPlateRef.current = resolved.palletId;
+      setPallet(resolved);
+      setItemGroup(null);
       setSelection({ location: null, validation: null });
       setWarehouseOverride(null);
       setPlateInput('');
+      // Best-effort: show the item's SAP item group as its "type".
+      if (resolved.itemCode) {
+        void barcodeApi.getOitmItemGroup(resolved.itemCode).then((group) => {
+          if (requestedPlateRef.current !== resolved.palletId || !group) return;
+          setItemGroup(
+            group.item_group_name ||
+              (group.item_group_code != null ? `Group ${group.item_group_code}` : null),
+          );
+        });
+      }
     } catch (error) {
       notifyFail(error instanceof Error ? error.message : 'Could not look up that pallet.');
     } finally {
@@ -151,7 +170,9 @@ export default function WmsReceivePage() {
   }, []);
 
   function clearPallet() {
+    requestedPlateRef.current = '';
     setPallet(null);
+    setItemGroup(null);
     setSelection({ location: null, validation: null });
     setWarehouseOverride(null);
     setPlateInput('');


### PR DESCRIPTION
## Warehouse Ops / BST integration

- **BST → WMS putaway**: on the BST Receive page, assign a Warehouse Ops bin to an accepted pallet (reusable smart bin picker); gated behind the WMS master flag; supports stock-transfer and invoice BSTs with a cross-company guard.
- **Pallet-first WMS Receive**: scan a pallet → details resolve from the barcode module and show as read-only text → scan/pick the location → place. No manual item entry.
- **Item type = SAP item group**: shows the scanned item's group name (needs the paired `factory_app` PR for `/barcode/items/oitm/detail/`).
- **Operator picks the receive destination warehouse** (no longer inferred from the pallet's source) — scales to multiple warehouses.
- **Richer location detail panel** on the map: status/barcode/temperature/material-rule/reservation details + per-pallet/inventory item, box count, units, lot, expiry.
- **Map hover tooltip** now lists a cell's stored contents.

**Checks:** `tsc`, `eslint`, `vite build`, and the WMS vitest suite all green.

> Depends on `nareshKumar421/factory_app` PR (OITM item-group endpoint) for the Item type field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)