### PR TITLE
feat(wms): map audit trail, find-a-pallet & phantom-pallet delete

### DIFF
--- a/src/modules/wms/components/LocationDetailPanel.tsx
+++ b/src/modules/wms/components/LocationDetailPanel.tsx
@@ -6,7 +6,7 @@
  * actions (wired through the barcode scanner) let the operator pick a pallet
  * here up for relocation, or scan a pallet to place into this location.
  */
-import { MoveRight, PackagePlus } from 'lucide-react';
+import { MoveRight, PackagePlus, Trash2 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -45,6 +45,8 @@ interface LocationDetailPanelProps {
   onMovePallet?: (pallet: Pallet) => void;
   /** Scan a pallet elsewhere to move it into this location. */
   onPlacePalletHere?: (scannedCode: string) => void;
+  /** Remove a phantom pallet from this location (bin is actually empty). */
+  onRemovePallet?: (pallet: Pallet) => void;
   /** The most recent movements for this location (the audit-trail preview). */
   recentMovements?: MovementLogEntry[];
   movementsLoading?: boolean;
@@ -124,6 +126,7 @@ export function LocationDetailPanel({
   inventoryHere,
   onMovePallet,
   onPlacePalletHere,
+  onRemovePallet,
   recentMovements,
   movementsLoading,
   locationCodeById,
@@ -234,6 +237,17 @@ export function LocationDetailPanel({
                       {onMovePallet ? (
                         <Button variant="outline" size="sm" onClick={() => onMovePallet(pallet)}>
                           <MoveRight className="mr-1 h-3.5 w-3.5" /> Move
+                        </Button>
+                      ) : null}
+                      {onRemovePallet ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive hover:text-destructive"
+                          title="Remove from this location (bin is empty)"
+                          onClick={() => onRemovePallet(pallet)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
                         </Button>
                       ) : null}
                     </div>

--- a/src/modules/wms/components/LocationDetailPanel.tsx
+++ b/src/modules/wms/components/LocationDetailPanel.tsx
@@ -7,6 +7,7 @@
  * here up for relocation, or scan a pallet to place into this location.
  */
 import { MoveRight, PackagePlus } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 import {
   Badge,
@@ -21,7 +22,14 @@ import {
 
 import type { LocationOccupancy } from '../services';
 import { DISPLAY_STATUS_META } from '../services';
-import type { CellPurpose, InventoryRecord, Pallet, WarehouseLocation } from '../types';
+import type {
+  CellPurpose,
+  InventoryRecord,
+  MovementLogEntry,
+  Pallet,
+  WarehouseLocation,
+} from '../types';
+import { MovementItem } from './MovementItem';
 import { WmsPrintLabelButton } from './WmsPrintLabelButton';
 import { WmsScanButton } from './WmsScanButton';
 
@@ -37,6 +45,11 @@ interface LocationDetailPanelProps {
   onMovePallet?: (pallet: Pallet) => void;
   /** Scan a pallet elsewhere to move it into this location. */
   onPlacePalletHere?: (scannedCode: string) => void;
+  /** The most recent movements for this location (the audit-trail preview). */
+  recentMovements?: MovementLogEntry[];
+  movementsLoading?: boolean;
+  /** Location id → code, to name the counterpart location in a movement. */
+  locationCodeById?: Map<string, string>;
 }
 
 function Usage({ label, used, max, unit }: { label: string; used: number; max: number | null; unit?: string }) {
@@ -111,6 +124,9 @@ export function LocationDetailPanel({
   inventoryHere,
   onMovePallet,
   onPlacePalletHere,
+  recentMovements,
+  movementsLoading,
+  locationCodeById,
 }: LocationDetailPanelProps) {
   if (!location) return null;
   const meta = occupancy ? DISPLAY_STATUS_META[occupancy.status] : null;
@@ -260,6 +276,41 @@ export function LocationDetailPanel({
               ))
             )}
           </section>
+
+          {/* Audit trail — the most recent movements, with a link to the full,
+              paginated history for this cell. */}
+          {isStorage ? (
+            <>
+              <Separator />
+              <section className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold">Recent movements</h3>
+                  <Link
+                    to={`/warehouse-ops/locations/${location.id}/history`}
+                    className="text-xs font-medium text-primary hover:underline"
+                  >
+                    View full history →
+                  </Link>
+                </div>
+                {movementsLoading ? (
+                  <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : !recentMovements || recentMovements.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No movements recorded.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {recentMovements.slice(0, 3).map((entry) => (
+                      <MovementItem
+                        key={entry.id}
+                        entry={entry}
+                        thisLocationId={location.id}
+                        codeById={locationCodeById}
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
+            </>
+          ) : null}
         </div>
 
         {/* Scan-driven actions */}

--- a/src/modules/wms/components/MovementItem.tsx
+++ b/src/modules/wms/components/MovementItem.tsx
@@ -1,0 +1,69 @@
+/**
+ * One movement in a location's audit trail — compact, reused by the map detail
+ * panel (last few) and the full paginated history page.
+ *
+ * Relative to `thisLocationId`, each entry reads as In (stock arrived here) or
+ * Out (left here); the counterpart location's code is shown when resolvable via
+ * `codeById`.
+ */
+import { Badge } from '@/shared/components/ui';
+
+import type { MovementLogEntry, WmsId } from '../types';
+
+/** ISO datetime → "YYYY-MM-DD HH:MM". */
+function formatWhen(iso: string): string {
+  if (!iso) return '';
+  return iso.length >= 16 ? `${iso.slice(0, 10)} ${iso.slice(11, 16)}` : iso.slice(0, 10);
+}
+
+interface MovementItemProps {
+  entry: MovementLogEntry;
+  /** The cell whose trail this is — drives the In/Out direction. */
+  thisLocationId?: WmsId;
+  /** Location id → code, to name the counterpart location. */
+  codeById?: Map<string, string>;
+}
+
+export function MovementItem({ entry, thisLocationId, codeById }: MovementItemProps) {
+  const isIn = thisLocationId != null && entry.toLocationId === thisLocationId;
+  const isOut = thisLocationId != null && entry.fromLocationId === thisLocationId;
+  const counterpartId = isIn ? entry.fromLocationId : entry.toLocationId;
+  const counterpartCode = counterpartId ? codeById?.get(counterpartId) : null;
+  const item = entry.itemName || entry.itemCode || (entry.palletId ? 'Pallet' : '—');
+
+  return (
+    <div className="flex items-start justify-between gap-2 rounded-md border p-2 text-sm">
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5">
+          <Badge variant="outline" className="text-[10px]">
+            {entry.type}
+          </Badge>
+          <span className="truncate">{item}</span>
+          {entry.discrepancy ? (
+            <span className="text-amber-600" title="Discrepancy">
+              Δ
+            </span>
+          ) : null}
+        </div>
+        <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+          {entry.quantity ? <span>{entry.quantity}</span> : null}
+          {entry.boxCount ? (
+            <span>
+              {entry.boxCount} box{entry.boxCount === 1 ? '' : 'es'}
+            </span>
+          ) : null}
+          {isIn || isOut ? (
+            <span>
+              {isIn ? 'In' : 'Out'}
+              {counterpartCode ? ` ${isIn ? 'from' : 'to'} ${counterpartCode}` : ''}
+            </span>
+          ) : null}
+          {entry.userName ? <span>· {entry.userName}</span> : null}
+        </div>
+      </div>
+      <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+        {formatWhen(entry.createdAt)}
+      </span>
+    </div>
+  );
+}

--- a/src/modules/wms/module.config.tsx
+++ b/src/modules/wms/module.config.tsx
@@ -26,6 +26,7 @@ const WmsDesignerPage = lazy(() => import('./pages/WmsDesignerPage'));
 const WmsWarehousesPage = lazy(() => import('./pages/WmsWarehousesPage'));
 const WmsWarehouseEditorPage = lazy(() => import('./pages/WmsWarehouseEditorPage'));
 const WmsMapPage = lazy(() => import('./pages/WmsMapPage'));
+const WmsLocationHistoryPage = lazy(() => import('./pages/WmsLocationHistoryPage'));
 const WmsTransferPage = lazy(() => import('./pages/WmsTransferPage'));
 const WmsReceivePage = lazy(() => import('./pages/WmsReceivePage'));
 const WmsOutboundPage = lazy(() => import('./pages/WmsOutboundPage'));
@@ -64,6 +65,13 @@ export const wmsModuleConfig: ModuleConfig = {
       layout: 'main',
       permissions: WMS_ACCESS,
       breadcrumb: { label: 'Map' },
+    },
+    {
+      path: '/warehouse-ops/locations/:locationId/history',
+      element: <WmsLocationHistoryPage />,
+      layout: 'main',
+      permissions: WMS_ACCESS,
+      breadcrumb: { label: 'Movement history' },
     },
     {
       path: '/warehouse-ops/receive',

--- a/src/modules/wms/pages/WmsLocationHistoryPage.tsx
+++ b/src/modules/wms/pages/WmsLocationHistoryPage.tsx
@@ -1,0 +1,127 @@
+/**
+ * Full movement audit trail for one location, server-paginated.
+ *
+ * Reached from the map's location detail panel ("View full history"). Movements
+ * are unbounded in an FMCG warehouse, so every page is fetched on demand via
+ * `useLocationMovements` (newest first) rather than loading the whole
+ * `movements` collection.
+ */
+import { ArrowLeft } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { Button, Card, CardContent } from '@/shared/components/ui';
+
+import { MovementItem } from '../components/MovementItem';
+import { WmsDisabledNotice } from '../components/WmsDisabledNotice';
+import { useLocationMovements, useWarehouses, useWmsCollection, useWmsEnabled } from '../store';
+
+const PAGE_SIZE = 25;
+
+export default function WmsLocationHistoryPage() {
+  const enabled = useWmsEnabled();
+  const { locationId = '' } = useParams<{ locationId: string }>();
+  const { data: locations } = useWmsCollection('locations');
+  const { warehouses } = useWarehouses();
+  const [page, setPage] = useState(0);
+
+  const location = useMemo(
+    () => locations.find((item) => item.id === locationId) ?? null,
+    [locations, locationId],
+  );
+  const warehouse = useMemo(
+    () => (location ? warehouses.find((item) => item.id === location.warehouseId) ?? null : null),
+    [warehouses, location],
+  );
+  const codeById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const item of locations) map.set(item.id, item.code);
+    return map;
+  }, [locations]);
+
+  const { movements, count, loading, error } = useLocationMovements(
+    locationId || null,
+    PAGE_SIZE,
+    page * PAGE_SIZE,
+  );
+  const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
+
+  if (!enabled) {
+    return (
+      <div className="mx-auto max-w-3xl p-4 md:p-6">
+        <WmsDisabledNotice />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-4 md:p-6">
+      <div>
+        <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
+          <Link to="/warehouse-ops/map">
+            <ArrowLeft className="mr-1 h-4 w-4" /> Back to map
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Movement history
+          {location ? (
+            <span className="ml-2 font-mono text-xl text-muted-foreground">{location.code}</span>
+          ) : null}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {warehouse ? `${warehouse.name} · ` : ''}
+          {count} movement{count === 1 ? '' : 's'}
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="space-y-2 py-4">
+          {loading ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">Loading…</p>
+          ) : error ? (
+            <p className="py-8 text-center text-sm text-destructive">Could not load movements.</p>
+          ) : movements.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              No movements recorded for this location.
+            </p>
+          ) : (
+            movements.map((entry) => (
+              <MovementItem
+                key={entry.id}
+                entry={entry}
+                thisLocationId={locationId}
+                codeById={codeById}
+              />
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      {count > PAGE_SIZE ? (
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">
+            Page {page + 1} of {totalPages}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page === 0 || loading}
+              onClick={() => setPage((current) => Math.max(0, current - 1))}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages - 1 || loading}
+              onClick={() => setPage((current) => current + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/modules/wms/pages/WmsMapPage.tsx
+++ b/src/modules/wms/pages/WmsMapPage.tsx
@@ -103,6 +103,11 @@ export default function WmsMapPage() {
   const [detailId, setDetailId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
+  // "Find pallet" cross-warehouse jump + phantom-pallet removal.
+  const [pendingFocusId, setPendingFocusId] = useState<string | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<Pallet | null>(null);
+  const [removing, setRemoving] = useState(false);
+
   // Scan-driven move state.
   const [moveSession, setMoveSession] = useState<Pallet | null>(null);
   const [pendingMove, setPendingMove] = useState<PendingMove | null>(null);
@@ -381,6 +386,57 @@ export default function WmsMapPage() {
     if (exact) openDetail(exact.id);
   }
 
+  // Scan a pallet to find WHERE it is — jump to its cell (switching warehouse if
+  // it sits in a different one) and report the location.
+  async function findPallet(code: string) {
+    const key = code.trim().toLowerCase();
+    if (!key) return;
+    const pallet = pallets.find(
+      (p) => p.licensePlate.toLowerCase() === key && p.status !== 'SHIPPED',
+    );
+    if (!pallet) {
+      notifyFail('No pallet matched that code.');
+      return;
+    }
+    if (!pallet.currentLocationId) {
+      notifyFail(`Pallet ${pallet.licensePlate} is not placed in any location.`);
+      return;
+    }
+    const here = locations.find((location) => location.id === pallet.currentLocationId);
+    if (here) {
+      focusLocation(here.id);
+      notifyOk(`Pallet ${pallet.licensePlate} is in ${here.code}.`);
+      return;
+    }
+    // In a different warehouse — resolve the location, switch to it, then focus.
+    const location = await wmsStore.get('locations', pallet.currentLocationId);
+    if (!location) {
+      notifyFail(`Could not find where pallet ${pallet.licensePlate} is placed.`);
+      return;
+    }
+    notifyOk(`Pallet ${pallet.licensePlate} is in ${location.code} — switching warehouse.`);
+    setPendingFocusId(location.id);
+    setSearchParams({ warehouse: location.warehouseId });
+  }
+
+  async function confirmRemove() {
+    if (!removeTarget) return;
+    setRemoving(true);
+    try {
+      await wmsStore.removePalletFromLocation(
+        removeTarget.id,
+        undefined,
+        'Removed from map — bin was empty',
+      );
+      notifyOk(`Removed pallet ${removeTarget.licensePlate} from the map.`);
+      setRemoveTarget(null);
+    } catch (error) {
+      notifyFail(error instanceof Error ? error.message : 'Could not remove the pallet.');
+    } finally {
+      setRemoving(false);
+    }
+  }
+
   // ── Move workflow ────────────────────────────────────────────────────────
   function startMoveForPallet(pallet: Pallet) {
     setMoveSession(pallet);
@@ -485,6 +541,16 @@ export default function WmsMapPage() {
     cancelMove();
   }, [selectedId]);
 
+  // Complete a cross-warehouse "find pallet" once the target warehouse's
+  // locations have loaded.
+  useEffect(() => {
+    if (pendingFocusId && locations.some((location) => location.id === pendingFocusId)) {
+      focusLocation(pendingFocusId);
+      setPendingFocusId(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingFocusId, locations]);
+
   const detailLocation = detailId ? locations.find((location) => location.id === detailId) ?? null : null;
 
   // Recent movements for the open location (audit-trail preview in the panel),
@@ -528,7 +594,10 @@ export default function WmsMapPage() {
         </div>
         <div className="flex w-full items-center gap-2 sm:w-auto">
           {!moveSession ? (
-            <WmsScanButton label="Move pallet" onScan={resolveAndStartMove} />
+            <>
+              <WmsScanButton label="Find pallet" onScan={findPallet} />
+              <WmsScanButton label="Move pallet" onScan={resolveAndStartMove} />
+            </>
           ) : null}
           <NativeSelect
             className="w-full sm:w-48"
@@ -685,6 +754,7 @@ export default function WmsMapPage() {
         inventoryHere={detailLocation ? inventoryByLocation.get(detailLocation.id) ?? [] : []}
         onMovePallet={startMoveForPallet}
         onPlacePalletHere={placePalletHere}
+        onRemovePallet={setRemoveTarget}
         recentMovements={recentMovements.movements}
         movementsLoading={recentMovements.loading}
         locationCodeById={locationCodeById}
@@ -729,6 +799,32 @@ export default function WmsMapPage() {
             </Button>
             <Button disabled={busy || !pendingValidation?.ok} onClick={() => void confirmMove()}>
               {pendingValidation && !pendingValidation.ok ? 'Cannot move' : 'Confirm move'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove-pallet (phantom cleanup) confirmation */}
+      <Dialog open={removeTarget != null} onOpenChange={(open) => !open && setRemoveTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove pallet from the map?</DialogTitle>
+            <DialogDescription>
+              {removeTarget ? (
+                <>
+                  This deletes pallet{' '}
+                  <span className="font-mono font-medium">{removeTarget.licensePlate}</span> and its
+                  stock from Warehouse Ops. Use this only when the bin is physically empty.
+                </>
+              ) : null}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveTarget(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" disabled={removing} onClick={() => void confirmRemove()}>
+              {removing ? 'Removing…' : 'Remove'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/modules/wms/pages/WmsMapPage.tsx
+++ b/src/modules/wms/pages/WmsMapPage.tsx
@@ -48,6 +48,7 @@ import {
   validatePalletMove,
 } from '../services';
 import {
+  useLocationMovements,
   useWarehouseLayout,
   useWarehouses,
   useWmsCollection,
@@ -486,6 +487,15 @@ export default function WmsMapPage() {
 
   const detailLocation = detailId ? locations.find((location) => location.id === detailId) ?? null : null;
 
+  // Recent movements for the open location (audit-trail preview in the panel),
+  // fetched on demand — movements are unbounded, so never cached in full.
+  const recentMovements = useLocationMovements(detailOpen && detailId ? detailId : null, 3, 0);
+  const locationCodeById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const location of locations) map.set(location.id, location.code);
+    return map;
+  }, [locations]);
+
   if (!enabled) {
     return (
       <div className="mx-auto max-w-3xl p-4 md:p-6">
@@ -675,6 +685,9 @@ export default function WmsMapPage() {
         inventoryHere={detailLocation ? inventoryByLocation.get(detailLocation.id) ?? [] : []}
         onMovePallet={startMoveForPallet}
         onPlacePalletHere={placePalletHere}
+        recentMovements={recentMovements.movements}
+        movementsLoading={recentMovements.loading}
+        locationCodeById={locationCodeById}
       />
 
       {/* Move confirmation */}

--- a/src/modules/wms/storage/adapter.types.ts
+++ b/src/modules/wms/storage/adapter.types.ts
@@ -72,6 +72,23 @@ export interface WmsStorageAdapter {
     params?: { warehouseId?: WmsId },
   ): Promise<WmsCollectionMap[K][]>;
 
+  /**
+   * Fetch ONE server-paginated page of a collection, with the total count.
+   * ``locationId`` filters to the rows touching a cell (a movement's from/to) —
+   * the audit trail; ``order: '-created_at'`` reads newest-first. Used for large
+   * collections (movements) that must not be pulled in full.
+   */
+  listPage<K extends WmsCollection>(
+    collection: K,
+    params: {
+      limit: number;
+      offset?: number;
+      warehouseId?: WmsId;
+      locationId?: WmsId;
+      order?: '-created_at';
+    },
+  ): Promise<{ results: WmsCollectionMap[K][]; count: number }>;
+
   get<K extends WmsCollection>(
     collection: K,
     id: WmsId,

--- a/src/modules/wms/storage/apiAdapter.ts
+++ b/src/modules/wms/storage/apiAdapter.ts
@@ -51,6 +51,31 @@ export class ApiAdapter implements WmsStorageAdapter {
     return unwrapList<WmsCollectionMap[K]>(response.data);
   }
 
+  async listPage<K extends WmsCollection>(
+    collection: K,
+    params: {
+      limit: number;
+      offset?: number;
+      warehouseId?: WmsId;
+      locationId?: WmsId;
+      order?: '-created_at';
+    },
+  ): Promise<{ results: WmsCollectionMap[K][]; count: number }> {
+    const query = new URLSearchParams();
+    query.set('limit', String(params.limit));
+    if (params.offset) query.set('offset', String(params.offset));
+    if (params.warehouseId) query.set('warehouseId', params.warehouseId);
+    if (params.locationId) query.set('locationId', params.locationId);
+    if (params.order) query.set('order', params.order);
+    const response = await apiClient.get(`${collectionUrl(collection)}?${query.toString()}`);
+    const data = response.data as { count?: number } | unknown;
+    const count =
+      data && typeof data === 'object' && typeof (data as { count?: number }).count === 'number'
+        ? (data as { count: number }).count
+        : 0;
+    return { results: unwrapList<WmsCollectionMap[K]>(response.data), count };
+  }
+
   async get<K extends WmsCollection>(collection: K, id: WmsId): Promise<WmsCollectionMap[K] | null> {
     try {
       const response = await apiClient.get<WmsCollectionMap[K]>(collectionUrl(collection, id));

--- a/src/modules/wms/store/index.ts
+++ b/src/modules/wms/store/index.ts
@@ -2,6 +2,8 @@ export type { ExternalPalletPlacement, ExternalPalletSnapshot, MirrorResult, Syn
 export { useWmsPalletMirror, useWmsPalletSync } from './usePalletMirror';
 export type { WarehouseEditor } from './useWarehouseEditor';
 export { useWarehouseEditor } from './useWarehouseEditor';
+export type { UseLocationMovementsResult } from './useLocationMovements';
+export { useLocationMovements } from './useLocationMovements';
 export type { WarehouseLayout } from './useWarehouses';
 export { useWarehouseLayout,useWarehouses } from './useWarehouses';
 export type { UseWmsSettingsResult } from './useWmsSettings';

--- a/src/modules/wms/store/useLocationMovements.ts
+++ b/src/modules/wms/store/useLocationMovements.ts
@@ -1,0 +1,67 @@
+/**
+ * Fetch one page of a location's movement audit trail (newest first).
+ *
+ * Movements are unbounded in an FMCG warehouse, so they are fetched on demand,
+ * server-paginated — never pulled into the cached `movements` collection. Pass
+ * `locationId = null` to fetch nothing (e.g. while the detail panel is closed).
+ *
+ * State is only ever set inside the async callbacks; `loading` is derived from
+ * whether the last fetched page matches the current request key (so no
+ * synchronous setState runs in the effect body).
+ */
+import { useEffect, useState } from 'react';
+
+import type { MovementLogEntry, WmsId } from '../types';
+import { wmsStore } from './wmsStore';
+
+export interface UseLocationMovementsResult {
+  movements: MovementLogEntry[];
+  /** Total movements for this location across all pages. */
+  count: number;
+  loading: boolean;
+  error: boolean;
+}
+
+interface Fetched {
+  movements: MovementLogEntry[];
+  count: number;
+  /** The request key the fetched page belongs to. */
+  key: string;
+}
+
+export function useLocationMovements(
+  locationId: WmsId | null,
+  limit: number,
+  offset = 0,
+): UseLocationMovementsResult {
+  const key = locationId ? `${locationId}:${limit}:${offset}` : '';
+  const [fetched, setFetched] = useState<Fetched>({ movements: [], count: 0, key: '__init__' });
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!locationId) return;
+    let cancelled = false;
+    wmsStore
+      .listLocationMovements(locationId, limit, offset)
+      .then((page) => {
+        if (cancelled) return;
+        setFetched({ movements: page.results, count: page.count, key });
+        setError(false);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [locationId, limit, offset, key]);
+
+  if (!locationId) return { movements: [], count: 0, loading: false, error: false };
+  const stale = fetched.key !== key;
+  return {
+    movements: stale ? [] : fetched.movements,
+    count: stale ? 0 : fetched.count,
+    loading: stale,
+    error: stale ? false : error,
+  };
+}

--- a/src/modules/wms/store/wmsStore.ts
+++ b/src/modules/wms/store/wmsStore.ts
@@ -186,6 +186,20 @@ class WmsStore {
     return this.adapter().get(collection, id);
   }
 
+  /**
+   * One server-paginated page of a location's movement audit trail, newest
+   * first. Movements are unbounded (FMCG), so this is fetched on demand rather
+   * than pulled into the cached `movements` collection.
+   */
+  listLocationMovements(locationId: WmsId, limit: number, offset: number) {
+    return this.adapter().listPage('movements', {
+      locationId,
+      limit,
+      offset,
+      order: '-created_at',
+    });
+  }
+
   async create<K extends WmsCollection>(
     collection: K,
     record: WmsCollectionMap[K],

--- a/src/modules/wms/store/wmsStore.ts
+++ b/src/modules/wms/store/wmsStore.ts
@@ -900,6 +900,43 @@ class WmsStore {
   }
 
   /**
+   * Delete a pallet and its stock from the map — the manual "this bin is
+   * actually empty" cleanup for a phantom pallet that never physically arrived
+   * or already left. Removes the pallet + its inventory and logs an ADJUSTMENT
+   * so the location's audit trail records the correction.
+   */
+  async removePalletFromLocation(
+    palletId: WmsId,
+    actor?: MoveActor,
+    note?: string,
+  ): Promise<void> {
+    const adapter = this.adapter();
+    const pallet = (await adapter.list('pallets')).find((p) => p.id === palletId);
+    if (!pallet) return;
+    const stock = (await adapter.list('inventory')).filter((r) => r.palletId === palletId);
+    await Promise.all(stock.map((r) => adapter.remove('inventory', r.id)));
+    await adapter.remove('pallets', palletId);
+    if (pallet.currentLocationId) {
+      await adapter.create(
+        'movements',
+        makeMovement({
+          type: 'ADJUSTMENT',
+          itemCode: pallet.itemCode,
+          itemName: pallet.itemName,
+          palletId,
+          fromLocationId: pallet.currentLocationId,
+          toLocationId: null,
+          boxCount: pallet.boxCount,
+          userId: actor?.id,
+          userName: actor?.name,
+          note: note ?? 'Removed from map — bin was empty',
+        }),
+      );
+    }
+    await Promise.all([this.load('pallets'), this.load('inventory'), this.load('movements')]);
+  }
+
+  /**
    * Repair pallet ↔ inventory ↔ location consistency for existing data.
    *
    * Heals records orphaned by older bugs (e.g. an item-level move that left a


### PR DESCRIPTION
Warehouse Ops map enhancements:

- **Per-cell audit trail** — the location detail panel shows the 3 most recent movements with a **View full history** link to a new server-paginated history page (`/warehouse-ops/locations/:id/history`). Movements are fetched on demand (never cached in full) via a new adapter `listPage` + `useLocationMovements` hook; reusable `MovementItem` shows type, item, qty/boxes, In/Out + counterpart bin, user, time.
- **Find a pallet** — a 'Find pallet' scan on the map jumps to a pallet's cell (switching warehouse if it sits in another one) and reports the location.
- **Remove a phantom pallet** — a per-pallet delete in the location panel (behind a confirm) removes a pallet placed on a bin that's physically empty: deletes the WMS pallet + inventory and logs an ADJUSTMENT.

**Checks:** tsc, eslint, vite build all clean.

> Depends on the paired `nareshKumar421/factory_app` PR for the `?locationId=` movements filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)