### PR TITLE
feat(admin): add BST and Returnable approvals badges and pages

### DIFF
--- a/src/modules/admin/components/BstApprovalsBadge.tsx
+++ b/src/modules/admin/components/BstApprovalsBadge.tsx
@@ -1,0 +1,34 @@
+import { WAREHOUSE_PERMISSIONS } from '@/config/permissions';
+import { usePermission } from '@/core/auth';
+import { useBSTPartialTransfers } from '@/modules/warehouse/api';
+import { cn } from '@/shared/utils';
+
+/**
+ * Live count of BST partial-transfer requests waiting for a decision. Polls far
+ * slower than the approvals page itself — a sidebar pill does not need the 4s
+ * live cadence the queue uses.
+ */
+export function BstApprovalsBadge({ className }: { className?: string }) {
+  const { hasPermission } = usePermission();
+  const canApprove = hasPermission(WAREHOUSE_PERMISSIONS.APPROVE_BST_PARTIAL);
+
+  const { data } = useBSTPartialTransfers(
+    { status: 'PENDING' },
+    { enabled: canApprove, refetchInterval: canApprove ? 30_000 : false },
+  );
+
+  const count = data?.length ?? 0;
+  if (count <= 0) return null;
+
+  return (
+    <span
+      className={cn(
+        'inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1.5 text-[11px] font-semibold leading-none text-white',
+        className,
+      )}
+      aria-label={`${count} pending BST partial-transfer approval${count === 1 ? '' : 's'}`}
+    >
+      {count > 99 ? '99+' : count}
+    </span>
+  );
+}

--- a/src/modules/admin/components/ReturnableApprovalsBadge.tsx
+++ b/src/modules/admin/components/ReturnableApprovalsBadge.tsx
@@ -1,0 +1,31 @@
+import { RETURNABLE_PERMISSIONS } from '@/config/permissions';
+import { usePermission } from '@/core/auth';
+import { useReturnablePendingApproval } from '@/modules/maintenance/api';
+import { cn } from '@/shared/utils';
+
+/**
+ * Live count of returnable / non-returnable gate passes waiting for the higher
+ * authority's sign-off. Renders nothing when the queue is empty or the user
+ * cannot approve.
+ */
+export function ReturnableApprovalsBadge({ className }: { className?: string }) {
+  const { hasPermission } = usePermission();
+  const canApprove = hasPermission(RETURNABLE_PERMISSIONS.APPROVE_GATEPASS);
+
+  const { data } = useReturnablePendingApproval(canApprove);
+
+  const count = data?.length ?? 0;
+  if (count <= 0) return null;
+
+  return (
+    <span
+      className={cn(
+        'inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1.5 text-[11px] font-semibold leading-none text-white',
+        className,
+      )}
+      aria-label={`${count} gate pass${count === 1 ? '' : 'es'} pending approval`}
+    >
+      {count > 99 ? '99+' : count}
+    </span>
+  );
+}

--- a/src/modules/admin/module.config.tsx
+++ b/src/modules/admin/module.config.tsx
@@ -1,12 +1,19 @@
 import { ShieldCheck } from 'lucide-react';
 
-import { ADMIN_PERMISSIONS, MAINTENANCE_PERMISSIONS } from '@/config/permissions';
+import {
+  ADMIN_PERMISSIONS,
+  MAINTENANCE_PERMISSIONS,
+  RETURNABLE_PERMISSIONS,
+  WAREHOUSE_PERMISSIONS,
+} from '@/config/permissions';
 import { lazyWithRetry as lazy } from '@/core/pwa/chunkReload';
 import type { ModuleConfig } from '@/core/types';
 
+import { BstApprovalsBadge } from './components/BstApprovalsBadge';
 import { DockingApprovalsBadge } from './components/DockingApprovalsBadge';
 import { MaterialIndentApprovalsBadge } from './components/MaterialIndentApprovalsBadge';
 import { PartialApprovalsBadge } from './components/PartialApprovalsBadge';
+import { ReturnableApprovalsBadge } from './components/ReturnableApprovalsBadge';
 
 const AdminDashboardPage = lazy(() => import('./pages/AdminDashboardPage'));
 const DockingScanApprovalsPage = lazy(() => import('./pages/DockingScanApprovalsPage'));
@@ -14,6 +21,12 @@ const DockingPartialScanApprovalsPage = lazy(
   () => import('./pages/DockingPartialScanApprovalsPage'),
 );
 const MaterialIndentApprovalsPage = lazy(() => import('./pages/MaterialIndentApprovalsPage'));
+const ReturnableApprovalsPage = lazy(() => import('./pages/ReturnableApprovalsPage'));
+// Same queue the Warehouse module exposes at /warehouse/bst/partial-approvals —
+// mirrored here so approvers find every queue in one place. One page, two routes.
+const BSTPartialApprovalsPage = lazy(
+  () => import('@/modules/warehouse/pages/bst/BSTPartialApprovalsPage'),
+);
 
 const dockingApprovalPermissions = [
   ADMIN_PERMISSIONS.DOCKING.VIEW_SCAN_SKIP,
@@ -32,10 +45,19 @@ const materialIndentApprovalPermissions = [
   MAINTENANCE_PERMISSIONS.APPROVE_MATERIAL_INDENT,
 ] as const;
 
+// Approve-only, for the same reason as material indents: VIEW_GATEPASS is held by
+// every department that raises a pass, so it must not pull the Admin module into
+// their sidebar.
+const returnableApprovalPermissions = [RETURNABLE_PERMISSIONS.APPROVE_GATEPASS] as const;
+
+const bstApprovalPermissions = [WAREHOUSE_PERMISSIONS.APPROVE_BST_PARTIAL] as const;
+
 const adminPermissions = [
   ...dockingApprovalPermissions,
   ...partialApprovalPermissions,
   ...materialIndentApprovalPermissions,
+  ...returnableApprovalPermissions,
+  ...bstApprovalPermissions,
 ] as const;
 
 export const adminModuleConfig: ModuleConfig = {
@@ -69,6 +91,20 @@ export const adminModuleConfig: ModuleConfig = {
       permissions: materialIndentApprovalPermissions,
       breadcrumb: { label: 'Material Indent Approvals' },
     },
+    {
+      path: '/admin/returnable-approvals',
+      element: <ReturnableApprovalsPage />,
+      layout: 'main',
+      permissions: returnableApprovalPermissions,
+      breadcrumb: { label: 'Returnable / Non-returnable Approvals' },
+    },
+    {
+      path: '/admin/bst-approvals',
+      element: <BSTPartialApprovalsPage />,
+      layout: 'main',
+      permissions: bstApprovalPermissions,
+      breadcrumb: { label: 'BST Approvals' },
+    },
   ],
   navigation: [
     {
@@ -97,6 +133,18 @@ export const adminModuleConfig: ModuleConfig = {
           title: 'Material Indent Approvals',
           permissions: materialIndentApprovalPermissions,
           badge: MaterialIndentApprovalsBadge,
+        },
+        {
+          path: '/admin/returnable-approvals',
+          title: 'Returnable / Non-returnable Approvals',
+          permissions: returnableApprovalPermissions,
+          badge: ReturnableApprovalsBadge,
+        },
+        {
+          path: '/admin/bst-approvals',
+          title: 'BST Approvals',
+          permissions: bstApprovalPermissions,
+          badge: BstApprovalsBadge,
         },
       ],
     },

--- a/src/modules/admin/pages/AdminDashboardPage.tsx
+++ b/src/modules/admin/pages/AdminDashboardPage.tsx
@@ -1,8 +1,13 @@
-import { ClipboardCheck, ClipboardList, Truck } from 'lucide-react';
+import { ClipboardCheck, ClipboardList, PackageCheck, ShieldCheck, Truck } from 'lucide-react';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { ADMIN_PERMISSIONS, MAINTENANCE_PERMISSIONS } from '@/config/permissions';
+import {
+  ADMIN_PERMISSIONS,
+  MAINTENANCE_PERMISSIONS,
+  RETURNABLE_PERMISSIONS,
+  WAREHOUSE_PERMISSIONS,
+} from '@/config/permissions';
 import { usePermission } from '@/core/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/components/ui';
 
@@ -48,6 +53,24 @@ const adminModuleCards: AdminModuleCard[] = [
       MAINTENANCE_PERMISSIONS.VIEW_MATERIAL_INDENT,
       MAINTENANCE_PERMISSIONS.APPROVE_MATERIAL_INDENT,
     ],
+  },
+  {
+    title: 'Returnable / Non-returnable Approvals',
+    description:
+      'Sign off on material leaving the gate for repair, exchange or job work before the gate sees it.',
+    route: '/admin/returnable-approvals',
+    icon: <PackageCheck className="h-5 w-5" />,
+    color: 'text-violet-700',
+    permissions: [RETURNABLE_PERMISSIONS.APPROVE_GATEPASS],
+  },
+  {
+    title: 'BST Partial-Transfer Approvals',
+    description:
+      'Review requests to seal a branch transfer whose scanned quantity is short of the bill.',
+    route: '/admin/bst-approvals',
+    icon: <ShieldCheck className="h-5 w-5" />,
+    color: 'text-teal-700',
+    permissions: [WAREHOUSE_PERMISSIONS.APPROVE_BST_PARTIAL],
   },
 ];
 

--- a/src/modules/admin/pages/ReturnableApprovalsPage.tsx
+++ b/src/modules/admin/pages/ReturnableApprovalsPage.tsx
@@ -1,0 +1,335 @@
+import { CheckCircle2, ExternalLink, Loader2, PackageCheck, ShieldQuestion, XCircle } from 'lucide-react';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { RETURNABLE_PERMISSIONS } from '@/config/permissions';
+import { usePermission } from '@/core/auth';
+import {
+  useApproveReturnable,
+  useRejectReturnable,
+  useReturnableGatePasses,
+  useReturnablePendingApproval,
+} from '@/modules/maintenance/api';
+import {
+  ReturnableStatusBadge,
+  ReturnableTypeBadge,
+} from '@/modules/maintenance/components/returnable';
+import type { ReturnableGatePassListItem } from '@/modules/maintenance/types';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Label,
+  Textarea,
+} from '@/shared/components/ui';
+import { getErrorMessage } from '@/shared/utils';
+
+type QueueTab = 'PENDING_APPROVAL' | 'PENDING_GATE_OUT';
+
+const TABS: { value: QueueTab; label: string }[] = [
+  { value: 'PENDING_APPROVAL', label: 'Pending Approval' },
+  { value: 'PENDING_GATE_OUT', label: 'Approved — At Gate' },
+];
+
+/**
+ * Admin-side mirror of the returnable / non-returnable approval step. The pass is
+ * still raised and closed inside Maintenance; this page only exists so approvers
+ * find every queue waiting on them in one place instead of hunting through the
+ * department's own register.
+ */
+export default function ReturnableApprovalsPage() {
+  const navigate = useNavigate();
+  const { hasPermission } = usePermission();
+  const canApprove = hasPermission(RETURNABLE_PERMISSIONS.APPROVE_GATEPASS);
+
+  const [tab, setTab] = useState<QueueTab>('PENDING_APPROVAL');
+
+  const pendingApproval = useReturnablePendingApproval(tab === 'PENDING_APPROVAL');
+  // The approved-and-waiting list is read-only context: it shows the approver what
+  // has already been handed to the gate but not yet gone out.
+  const pendingGateOut = useReturnableGatePasses(
+    { status: 'PENDING_GATE_OUT' },
+    tab === 'PENDING_GATE_OUT',
+  );
+
+  const { data: passes = [], isLoading } =
+    tab === 'PENDING_APPROVAL' ? pendingApproval : pendingGateOut;
+
+  const approvePass = useApproveReturnable();
+  const rejectPass = useRejectReturnable();
+
+  const [reviewTarget, setReviewTarget] = useState<ReturnableGatePassListItem | null>(null);
+  const [reviewMode, setReviewMode] = useState<'approve' | 'reject'>('approve');
+  const [remarks, setRemarks] = useState('');
+  const [reviewError, setReviewError] = useState('');
+
+  const isSaving = approvePass.isPending || rejectPass.isPending;
+
+  const openReview = (pass: ReturnableGatePassListItem, mode: 'approve' | 'reject') => {
+    setReviewTarget(pass);
+    setReviewMode(mode);
+    setRemarks('');
+    setReviewError('');
+  };
+
+  const closeReview = () => {
+    if (isSaving) return;
+    setReviewTarget(null);
+  };
+
+  const submitReview = async () => {
+    if (!reviewTarget) return;
+    const trimmed = remarks.trim();
+    if (reviewMode === 'reject' && !trimmed) {
+      setReviewError('A reason is required when sending a pass back.');
+      return;
+    }
+    setReviewError('');
+    try {
+      if (reviewMode === 'approve') {
+        await approvePass.mutateAsync({
+          passId: reviewTarget.id,
+          payload: { remarks: trimmed },
+        });
+        toast.success(`${reviewTarget.pass_no} approved and sent to the gate`);
+      } else {
+        await rejectPass.mutateAsync({
+          passId: reviewTarget.id,
+          payload: { reason: trimmed },
+        });
+        toast.success(`${reviewTarget.pass_no} sent back to the department`);
+      }
+      setReviewTarget(null);
+    } catch (error) {
+      setReviewError(getErrorMessage(error, 'Unable to save this decision'));
+    }
+  };
+
+  return (
+    <div className="space-y-6 pb-6">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight">
+          Returnable / Non-returnable Approvals
+        </h2>
+        <p className="text-muted-foreground">
+          Sign off on material leaving the gate for repair, exchange or job work. Approving releases
+          the pass to the gate; sending it back returns it to the department as a draft.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="border-b">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <CardTitle className="flex items-center gap-2 text-xl">
+              <PackageCheck className="h-5 w-5" />
+              Gate Passes
+            </CardTitle>
+            <div className="flex flex-wrap gap-2">
+              {TABS.map((item) => (
+                <Button
+                  key={item.value}
+                  type="button"
+                  size="sm"
+                  variant={tab === item.value ? 'default' : 'outline'}
+                  onClick={() => setTab(item.value)}
+                >
+                  {item.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center gap-2 p-10 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading gate passes...
+            </div>
+          ) : passes.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 p-10 text-center text-muted-foreground">
+              <ShieldQuestion className="h-8 w-8" />
+              <p>No {TABS.find((t) => t.value === tab)?.label.toLowerCase()} gate passes.</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[1040px] text-sm">
+                <thead className="border-b bg-muted/50">
+                  <tr>
+                    <th className="p-3 text-left font-medium">Pass No</th>
+                    <th className="p-3 text-left font-medium">Purpose / Dept</th>
+                    <th className="p-3 text-left font-medium">Going To</th>
+                    <th className="p-3 text-left font-medium">Items</th>
+                    <th className="p-3 text-left font-medium">Expected Back</th>
+                    <th className="p-3 text-left font-medium">Raised By</th>
+                    <th className="p-3 text-right font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {passes.map((pass) => (
+                    <tr key={pass.id} className="border-b align-top last:border-b-0">
+                      <td className="p-3">
+                        <button
+                          type="button"
+                          className="flex items-center gap-1 font-medium hover:underline"
+                          onClick={() => navigate(`/maintenance/returnable/${pass.id}`)}
+                        >
+                          {pass.pass_no}
+                          <ExternalLink className="h-3 w-3 text-muted-foreground" />
+                        </button>
+                        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                          <ReturnableTypeBadge isReturnable={pass.is_returnable} />
+                          <ReturnableStatusBadge
+                            status={pass.status}
+                            isOverdue={pass.is_overdue}
+                            daysOverdue={pass.days_overdue}
+                          />
+                        </div>
+                        {pass.material_indent_no ? (
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            Indent {pass.material_indent_no}
+                          </div>
+                        ) : null}
+                      </td>
+                      <td className="p-3">
+                        <div className="font-medium">{pass.purpose_display || '-'}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {pass.department_name || '-'}
+                        </div>
+                      </td>
+                      <td className="p-3">
+                        <div className="max-w-[200px] whitespace-pre-wrap break-words">
+                          {pass.destination || '-'}
+                        </div>
+                      </td>
+                      <td className="p-3">
+                        <div className="max-w-[260px] whitespace-pre-wrap break-words">
+                          {pass.item_names || '-'}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {pass.item_count} item{pass.item_count === 1 ? '' : 's'}
+                        </div>
+                      </td>
+                      <td className="p-3">{formatDate(pass.expected_return_date)}</td>
+                      <td className="p-3">
+                        <div className="font-medium">{pass.created_by_name || '-'}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatTimestamp(pass.created_at)}
+                        </div>
+                      </td>
+                      <td className="p-3 text-right">
+                        {pass.status === 'PENDING_APPROVAL' && canApprove ? (
+                          <div className="flex justify-end gap-2">
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              disabled={isSaving}
+                              onClick={() => openReview(pass, 'approve')}
+                            >
+                              <CheckCircle2 className="h-4 w-4" />
+                              Approve
+                            </Button>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              className="border-red-200 text-red-700 hover:bg-red-50"
+                              disabled={isSaving}
+                              onClick={() => openReview(pass, 'reject')}
+                            >
+                              <XCircle className="h-4 w-4" />
+                              Reject
+                            </Button>
+                          </div>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            {pass.status === 'PENDING_APPROVAL' ? 'Awaiting approver' : 'With gate'}
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={Boolean(reviewTarget)} onOpenChange={(open) => (!open ? closeReview() : null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {reviewMode === 'approve' ? 'Approve Gate Pass' : 'Send Back to Department'}
+              {reviewTarget ? ` — ${reviewTarget.pass_no}` : ''}
+            </DialogTitle>
+            <DialogDescription>
+              {reviewMode === 'approve'
+                ? 'The pass moves to the gate, which will record the vehicle and let the material out.'
+                : 'The pass returns to the department as a draft. Explain what needs to change.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="returnable-decision-remarks">
+              {reviewMode === 'approve' ? 'Remarks (optional)' : 'Reason for sending back'}
+            </Label>
+            <Textarea
+              id="returnable-decision-remarks"
+              value={remarks}
+              onChange={(event) => {
+                setRemarks(event.target.value);
+                setReviewError('');
+              }}
+              placeholder={
+                reviewMode === 'approve'
+                  ? 'Add an optional note for the gate pass timeline'
+                  : 'Why is this pass being sent back?'
+              }
+            />
+            {reviewError ? <p className="text-sm text-destructive">{reviewError}</p> : null}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={closeReview} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant={reviewMode === 'reject' ? 'destructive' : 'default'}
+              onClick={() => void submitReview()}
+              disabled={isSaving}
+            >
+              {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {reviewMode === 'approve' ? 'Approve' : 'Reject'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat('en-IN', { dateStyle: 'medium' }).format(date);
+}
+
+function formatTimestamp(value?: string | null) {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '-';
+  return new Intl.DateTimeFormat('en-IN', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}

--- a/src/modules/dashboards/production/components/ProductionEconomics.tsx
+++ b/src/modules/dashboards/production/components/ProductionEconomics.tsx
@@ -1,37 +1,56 @@
+import { Coins, Factory, Info, Layers, Receipt } from 'lucide-react';
 import { useMemo } from 'react';
-import {
-  Area,
-  AreaChart,
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Cell,
-  Pie,
-  PieChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
 
 import { useCostAnalysisReport } from '@/modules/production/execution/api/execution.queries';
 import type { AnalyticsParams } from '@/modules/production/execution/types';
-import { ACCENTS } from '@/shared/components/dashboard';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/components/ui';
 import { formatCurrency } from '@/shared/utils';
 
 import {
   CHART_COLORS,
+  count,
   money,
   prettyLabel,
   type ProductionVariant,
 } from '../constants/production-dashboard.constants';
 
-const shortDate = (iso: string) => (iso?.length >= 10 ? iso.slice(5) : iso);
+/** A headline KPI tile. */
+function KpiTile({
+  icon: Icon,
+  label,
+  value,
+  hint,
+  tone,
+}: {
+  icon: typeof Coins;
+  label: string;
+  value: string;
+  hint?: string;
+  tone?: 'accent' | 'credit';
+}) {
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card/60 px-4 py-3 shadow-sm">
+      <div className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </div>
+      <div
+        className={`mt-1 text-2xl font-extrabold tabular-nums leading-none ${
+          tone === 'credit' ? 'text-emerald-600 dark:text-emerald-400' : ''
+        } ${tone === 'accent' ? 'text-primary' : ''}`}
+      >
+        {value}
+      </div>
+      {hint && <div className="mt-1 text-[11px] text-muted-foreground">{hint}</div>}
+    </div>
+  );
+}
 
 /**
- * Cost economics — where the money goes per unit. Shows the cost-category
- * breakdown (donut), the cost-per-unit trend, and cost-per-unit by line.
+ * Cost analysis — plain-language view of what each case costs. A KPI strip,
+ * a "where the money goes" category breakdown, and a per-SKU cost table
+ * (the clearest read for a single day). Cost is derived on the backend from
+ * running hours × Cost Master rates.
  */
 export function ProductionEconomics({
   params,
@@ -43,152 +62,208 @@ export function ProductionEconomics({
   const query = useCostAnalysisReport(params);
   const data = query.data;
 
-  const distribution = useMemo(() => {
-    const dist = data?.cost_distribution ?? {};
-    return Object.entries(dist)
-      .map(([key, v]) => ({ name: prettyLabel(key), amount: v.amount, percentage: v.percentage }))
-      .filter((d) => d.amount > 0)
-      .sort((a, b) => b.amount - a.amount);
+  const totals = useMemo(() => {
+    const s = data?.summary;
+    if (!s) return undefined;
+    return {
+      totalCost: s.total_cost,
+      wasteRecovery: s.total_waste_recovery ?? 0,
+      netCost: s.total_net_cost ?? s.total_cost,
+      perCase: s.avg_per_unit,
+      runCount: s.run_count,
+    };
   }, [data]);
 
-  const trend = useMemo(
-    () =>
-      (data?.trend ?? []).map((t) => ({
-        date: shortDate(t.date),
-        perUnit: t.per_unit_cost / (variant.unitsPerCase || 1),
-      })),
-    [data, variant.unitsPerCase],
-  );
+  // "Where the money goes" — granular cost lines (same categories as the
+  // per-run Run Cost page). Falls back to the rolled-up distribution.
+  const breakdown = useMemo(() => {
+    const cats = data?.category_breakdown;
+    let rows: { name: string; amount: number; credit: boolean }[];
+    if (cats && cats.length) {
+      rows = cats
+        .filter((c) => c.amount > 0)
+        .map((c) => ({ name: c.label, amount: c.amount, credit: c.is_credit }));
+    } else {
+      rows = Object.entries(data?.cost_distribution ?? {})
+        .map(([key, v]) => ({ name: prettyLabel(key), amount: v.amount, credit: false }))
+        .filter((d) => d.amount > 0);
+    }
+    rows.sort((a, b) => b.amount - a.amount);
+    const max = rows.reduce((m, r) => Math.max(m, r.amount), 0) || 1;
+    return { rows, max };
+  }, [data]);
 
-  const byLine = useMemo(
+  // Per-SKU cost — one row per run (a line usually runs one SKU per day).
+  const skuRows = useMemo(
     () =>
-      (data?.by_line ?? []).map((l) => ({
-        line: l.line,
-        perUnit: l.avg_per_unit / (variant.unitsPerCase || 1),
-      })),
-    [data, variant.unitsPerCase],
+      (data?.per_run ?? [])
+        .map((r) => ({
+          sku: r.product,
+          line: r.line,
+          cases: r.produced_qty,
+          total: r.net_cost || r.total_cost,
+          perCase: r.per_unit_cost,
+        }))
+        .sort((a, b) => b.total - a.total),
+    [data],
   );
 
   if (query.isLoading) {
     return <div className="h-72 animate-pulse rounded-2xl bg-muted/50" />;
   }
 
-  return (
-    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-      {/* cost breakdown donut */}
+  const hasCost = !!totals && totals.totalCost > 0;
+
+  if (!hasCost || !totals) {
+    return (
       <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Cost breakdown</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {distribution.length === 0 ? (
-            <p className="py-16 text-center text-sm text-muted-foreground">No cost data.</p>
-          ) : (
-            <div className="flex flex-col items-center gap-4 sm:flex-row lg:flex-col">
-              <div className="h-[180px] w-[180px] shrink-0">
-                <ResponsiveContainer width="100%" height="100%">
-                  <PieChart>
-                    <Pie
-                      data={distribution}
-                      dataKey="amount"
-                      nameKey="name"
-                      innerRadius={52}
-                      outerRadius={78}
-                      paddingAngle={2}
-                      stroke="none"
-                    >
-                      {distribution.map((d, i) => (
-                        <Cell key={d.name} fill={CHART_COLORS[i % CHART_COLORS.length]} />
-                      ))}
-                    </Pie>
-                    <Tooltip
-                      formatter={(value) => formatCurrency(Number(value))}
-                      contentStyle={{ borderRadius: 12, border: '1px solid rgba(0,0,0,0.08)', fontSize: 12 }}
-                    />
-                  </PieChart>
-                </ResponsiveContainer>
-              </div>
-              <div className="min-w-0 flex-1 space-y-1.5">
-                {distribution.map((d, i) => (
-                  <div key={d.name} className="flex items-center gap-2 text-xs">
-                    <span
-                      className="h-2.5 w-2.5 shrink-0 rounded-full"
-                      style={{ backgroundColor: CHART_COLORS[i % CHART_COLORS.length] }}
-                    />
-                    <span className="min-w-0 flex-1 truncate">{d.name}</span>
-                    <span className="font-medium tabular-nums">{money(d.amount)}</span>
-                    <span className="w-10 text-right tabular-nums text-muted-foreground">
-                      {d.percentage.toFixed(0)}%
-                    </span>
+        <CardContent className="py-14 text-center text-sm text-muted-foreground">
+          No cost yet for this day. Set rates in <strong>Cost Master</strong> and complete a run —
+          cost is computed from running hours × rates.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <KpiTile icon={Receipt} label="Total production cost" value={formatCurrency(totals.totalCost)} />
+        {totals.wasteRecovery > 0 ? (
+          <KpiTile
+            icon={Coins}
+            label="Net cost (after waste sale)"
+            value={formatCurrency(totals.netCost)}
+            hint={`Waste recovery −${money(totals.wasteRecovery)}`}
+          />
+        ) : (
+          <KpiTile icon={Factory} label="Runs costed" value={String(totals.runCount)} />
+        )}
+        <KpiTile
+          icon={Coins}
+          label={`Avg cost / ${variant.unitNoun}`}
+          value={formatCurrency(totals.perCase)}
+          tone="accent"
+        />
+        <KpiTile
+          icon={Layers}
+          label="Cheapest → dearest / case"
+          value={
+            skuRows.length
+              ? `${money(skuRows[skuRows.length - 1].perCase)} – ${money(skuRows[0].perCase)}`
+              : '—'
+          }
+        />
+      </div>
+
+      <p className="flex items-start gap-1.5 text-[11px] leading-snug text-muted-foreground">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        Cost is computed automatically from each run&apos;s <strong className="mx-0.5">running
+        hours</strong> × <strong className="mx-0.5">Cost Master</strong> rates (per-line override
+        &gt; company default), plus BOM material at last purchase price.
+      </p>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        {/* where the money goes */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Where the cost goes</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {breakdown.rows.length === 0 ? (
+              <p className="py-10 text-center text-sm text-muted-foreground">No cost categories.</p>
+            ) : (
+              breakdown.rows.map((r, i) => {
+                const pct = (r.amount / totals.totalCost) * 100;
+                const color = r.credit ? '#059669' : CHART_COLORS[i % CHART_COLORS.length];
+                return (
+                  <div key={r.name} className="space-y-1">
+                    <div className="flex items-baseline justify-between gap-2 text-xs">
+                      <span className="flex items-center gap-1.5 font-medium">
+                        <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />
+                        {r.name}
+                        {r.credit && (
+                          <span className="rounded bg-emerald-50 px-1 text-[9px] font-semibold text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300">
+                            credit
+                          </span>
+                        )}
+                      </span>
+                      <span className="tabular-nums">
+                        <span className="font-semibold">
+                          {r.credit ? '−' : ''}
+                          {money(r.amount)}
+                        </span>
+                        <span className="ml-1.5 text-muted-foreground">{pct.toFixed(0)}%</span>
+                      </span>
+                    </div>
+                    <div className="h-2 overflow-hidden rounded-full bg-muted">
+                      <div
+                        className="h-full rounded-full"
+                        style={{ width: `${(r.amount / breakdown.max) * 100}%`, backgroundColor: color }}
+                      />
+                    </div>
                   </div>
-                ))}
+                );
+              })
+            )}
+          </CardContent>
+        </Card>
+
+        {/* per-SKU cost table */}
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-base">Cost by SKU</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {skuRows.length === 0 ? (
+              <p className="py-10 text-center text-sm text-muted-foreground">No runs costed.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs text-muted-foreground">
+                      <th className="py-2 pr-2 font-medium">SKU / line</th>
+                      <th className="py-2 px-2 text-right font-medium">Cases</th>
+                      <th className="py-2 px-2 text-right font-medium">Total cost</th>
+                      <th className="py-2 pl-2 text-right font-medium">Cost / {variant.unitNoun}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {skuRows.map((r, i) => (
+                      <tr key={`${r.sku}-${i}`} className="border-b last:border-0">
+                        <td className="max-w-[260px] py-2 pr-2">
+                          <div className="truncate font-medium" title={r.sku}>
+                            {r.sku}
+                          </div>
+                          <div className="truncate text-[11px] text-muted-foreground">{r.line}</div>
+                        </td>
+                        <td className="py-2 px-2 text-right tabular-nums">{count(r.cases)}</td>
+                        <td className="py-2 px-2 text-right tabular-nums">{money(r.total)}</td>
+                        <td className="py-2 pl-2 text-right font-semibold tabular-nums text-primary">
+                          {formatCurrency(r.perCase)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                  <tfoot>
+                    <tr className="border-t-2 text-xs font-semibold">
+                      <td className="py-2 pr-2">Total · {totals.runCount} runs</td>
+                      <td className="py-2 px-2 text-right tabular-nums">
+                        {count(skuRows.reduce((s, r) => s + r.cases, 0))}
+                      </td>
+                      <td className="py-2 px-2 text-right tabular-nums">{money(totals.totalCost)}</td>
+                      <td className="py-2 pl-2 text-right tabular-nums text-primary">
+                        {formatCurrency(totals.perCase)}
+                      </td>
+                    </tr>
+                  </tfoot>
+                </table>
               </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* cost / unit trend */}
-      <Card className="lg:col-span-2">
-        <CardHeader>
-          <CardTitle className="text-base">Cost per {variant.unitNoun} · trend</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {trend.length === 0 ? (
-            <p className="py-16 text-center text-sm text-muted-foreground">No trend data.</p>
-          ) : (
-            <div className="h-[180px]">
-              <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={trend} margin={{ left: 8, right: 12, top: 8, bottom: 0 }}>
-                  <defs>
-                    <linearGradient id="costTrend" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="0%" stopColor={variant.accent.hex} stopOpacity={0.32} />
-                      <stop offset="100%" stopColor={variant.accent.hex} stopOpacity={0} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" vertical={false} />
-                  <XAxis dataKey="date" fontSize={10} tickMargin={8} axisLine={false} tickLine={false} />
-                  <YAxis fontSize={10} width={54} axisLine={false} tickLine={false} tickFormatter={(v: number) => money(v)} />
-                  <Tooltip
-                    formatter={(value) => [formatCurrency(Number(value)), `Per ${variant.unitNoun}`]}
-                    contentStyle={{ borderRadius: 12, border: '1px solid rgba(0,0,0,0.08)', fontSize: 12 }}
-                  />
-                  <Area
-                    type="monotone"
-                    dataKey="perUnit"
-                    stroke={variant.accent.hex}
-                    strokeWidth={2.5}
-                    fill="url(#costTrend)"
-                    dot={false}
-                    activeDot={{ r: 4 }}
-                  />
-                </AreaChart>
-              </ResponsiveContainer>
-            </div>
-          )}
-
-          {/* cost per unit by line */}
-          {byLine.length > 0 && (
-            <div className="mt-4 h-[140px]">
-              <p className="mb-1 text-xs font-medium text-muted-foreground">
-                Cost per {variant.unitNoun} by line
-              </p>
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={byLine} layout="vertical" margin={{ left: 8, right: 12 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" horizontal={false} />
-                  <XAxis type="number" fontSize={10} tickFormatter={(v: number) => money(v)} axisLine={false} tickLine={false} />
-                  <YAxis type="category" dataKey="line" width={90} fontSize={10} axisLine={false} tickLine={false} />
-                  <Tooltip
-                    formatter={(value) => [formatCurrency(Number(value)), `Per ${variant.unitNoun}`]}
-                    contentStyle={{ borderRadius: 12, border: '1px solid rgba(0,0,0,0.08)', fontSize: 12 }}
-                  />
-                  <Bar dataKey="perUnit" radius={[0, 6, 6, 0]} fill={ACCENTS.amber.hex} />
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+            )}
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/modules/production/execution/types/execution.types.ts
+++ b/src/modules/production/execution/types/execution.types.ts
@@ -1220,11 +1220,20 @@ export interface CostDistributionItem {
   percentage: number;
 }
 
+export interface CostCategoryBreakdown {
+  category: string;
+  label: string;
+  amount: number;
+  is_credit: boolean;
+  percentage: number;
+}
+
 export interface CostAnalysisReport {
   per_run: CostRunDetail[];
   trend: CostTrendPoint[];
   by_line: CostByLine[];
   cost_distribution: Record<string, CostDistributionItem>;
+  category_breakdown?: CostCategoryBreakdown[];
   summary: {
     total_cost: number;
     total_waste_recovery: number;

--- a/src/modules/warehouse/api/bst.queries.ts
+++ b/src/modules/warehouse/api/bst.queries.ts
@@ -21,6 +21,8 @@ export const BST_LIVE_POLL_MS = 4000;
 
 interface PollOptions {
   refetchInterval?: number | false;
+  /** Skip the request entirely — used by permission-gated sidebar badges. */
+  enabled?: boolean;
 }
 
 export const BST_QUERY_KEYS = {
@@ -157,6 +159,7 @@ export function useBSTPartialTransfers(params?: BSTListParams, options?: PollOpt
   return useQuery({
     queryKey: BST_QUERY_KEYS.partialTransfers(params),
     queryFn: () => bstApi.listPartialTransfers(params),
+    enabled: options?.enabled ?? true,
     refetchInterval: options?.refetchInterval,
   });
 }


### PR DESCRIPTION
- Implemented `BstApprovalsBadge` to display pending BST partial-transfer approvals.
- Implemented `ReturnableApprovalsBadge` to display pending returnable/non-returnable gate passes.
- Added routes and permissions for the new approvals pages in `module.config.tsx`.
- Created `ReturnableApprovalsPage` for managing returnable gate passes with approval and rejection functionality.
- Updated `AdminDashboardPage` to include new approvals in the dashboard.
- Enhanced cost analysis in `ProductionEconomics` to include detailed breakdowns and KPI tiles.
- Updated API queries to support conditional fetching based on permissions.